### PR TITLE
models: fix unique index on userEXT.id_user column

### DIFF
--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -235,7 +235,9 @@ class UserEXT(db.Model):
 
     user = db.relationship(User, backref="external_identifiers")
 
-    __table_args__ = (db.Index('id_user', id_user, method, unique=True),
-                      db.Model.__table_args__)
+    __table_args__ = (
+        db.Index('userext_id_user_method', id_user, method, unique=True),
+        db.Model.__table_args__
+    )
 
 __all__ = ('User', 'UserEXT')


### PR DESCRIPTION
* FIX Changes index definition in `UserEXT` model for `id_user`
  column.  (closes #5)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>