### PR TITLE
global: unifies helpers and utils into utils.py

### DIFF
--- a/invenio_accounts/helpers.py
+++ b/invenio_accounts/helpers.py
@@ -19,46 +19,15 @@
 
 """Helper methods for accounts."""
 
-from datetime import timedelta
+from warnings import warn
 
-from flask import g, render_template, url_for
-
-from invenio_base.globals import cfg
-from invenio_base.i18n import _
-from invenio.ext.email import send_email
-
-from .tokens import EmailConfirmationSerializer
+from . import utils
 
 
 def send_account_activation_email(user):
     """Send an account activation email."""
-    expires_in = cfg.get('CFG_WEBSESSION_ADDRESS_ACTIVATION_EXPIRE_IN_DAYS')
-
-    address_activation_key = EmailConfirmationSerializer(
-        expires_in=timedelta(days=expires_in).total_seconds()
-    ).create_token(user.id, {'email': user.email})
-
-    # Render context.
-    ctx = {
-        "ip_address": None,
-        "user": user,
-        "email": user.email,
-        "activation_link": url_for(
-            'webaccount.access',
-            mailcookie=address_activation_key,
-            _external=True,
-            _scheme='https',
-        ),
-        "days": expires_in,
-    }
-
-    # Send email
-    send_email(
-        cfg.get('CFG_SITE_SUPPORT_EMAIL'),
-        user.email,
-        _("Account registration at %(sitename)s",
-          sitename=cfg["CFG_SITE_NAME_INTL"].get(
-              getattr(g, 'ln', cfg['CFG_SITE_LANG']),
-              cfg['CFG_SITE_NAME'])),
-        render_template("accounts/emails/activation.tpl", **ctx)
-    )
+    warn(("invenio_accounts.helpers.send_account_actation_email "
+          "has been moved "
+          "to invenio_accounts.utils.send_account_activation_email"),
+         DeprecationWarning)
+    utils.send_account_activation_email(user)


### PR DESCRIPTION
* Moves invenio_accounts.helpers.send_account_activation_email to
  invenio_accounts.utils.send_account_activation_email.

* Deprecates invenio_accounts.helpers.send_account_activation_email.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>