### PR TITLE
upgrader: upgrade recipes fix

### DIFF
--- a/invenio_accounts/upgrades/accounts_2015_06_26_userext.py
+++ b/invenio_accounts/upgrades/accounts_2015_06_26_userext.py
@@ -32,7 +32,7 @@ def info():
 
 def do_upgrade():
     """Implement your upgrades here."""
-    with op.batch_alter_table("UserEXT") as batch_op:
+    with op.batch_alter_table("userEXT") as batch_op:
         batch_op.alter_column(
             column_name='id',
             type_=db.String(255), nullable=False
@@ -41,7 +41,7 @@ def do_upgrade():
 
 def estimate():
     """Estimate running time of upgrade in seconds (optional)."""
-    pass
+    return 1
 
 
 def pre_upgrade():

--- a/invenio_accounts/upgrades/accounts_2015_07_10_nickname_check_rules_changed.py
+++ b/invenio_accounts/upgrades/accounts_2015_07_10_nickname_check_rules_changed.py
@@ -19,6 +19,8 @@
 
 """Check if some of nicknames are not valid anymore."""
 
+from invenio.ext.sqlalchemy import db
+
 from invenio_accounts.models import User
 
 # Important: Below is only a best guess. You MUST validate which previous
@@ -43,15 +45,13 @@ def estimate():
 
 def pre_upgrade():
     """Run pre-upgrade checks (optional)."""
-    users = User.query.all()
-
     not_valid_nicknames = []
-    for user in users:
-        if not User.check_nickname(user.nickname):
-            not_valid_nicknames.append(user)
+    for user in db.engine.execute(db.select([User.nickname])):
+        if not User.check_nickname(user[0]):
+            not_valid_nicknames.append(user[0])
 
     if len(not_valid_nicknames) > 0:
-        list_users = ', '.join([u.nickname for u in not_valid_nicknames])
+        list_users = ', '.join(not_valid_nicknames)
         raise RuntimeError(
             "These nicknames are not valid: {list_users}. "
             "Please fix them before continuing.".format(


### PR DESCRIPTION
* FIX Adds return value to `userext` estimate method and fixes the
  table name.

* FIX Nickname check rules uses only the nickname column instead of all
  of them.

Signed-off-by: Esteban J. G. Gabancho <esteban.gabancho@gmail.com>