### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel coveralls"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -63,6 +63,7 @@ before_script:
   - "inveniomanage database create --quiet"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,7 @@ cache:
 
 env:
   - REQUIREMENTS=lowest REXTRAS=docs,tests
-  # Temporary disable release requirements until new Invenio version has been
-  # release:
-  #- REQUIREMENTS=release REXTRAS=docs,test
+  - REQUIREMENTS=release REXTRAS=docs,tests
   - REQUIREMENTS=devel REXTRAS=docs,tests
 
 python:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,7 +26,7 @@ include *.txt
 include LICENSE
 include pytest.ini
 include tox.ini
-include .editorconfig .dockerignore .travis.yml
+include .editorconfig .dockerignore .travis.yml .travis.invenio.cfg
 include babel.ini
 recursive-include invenio_accounts *.po
 recursive-include invenio_accounts *.pot

--- a/invenio_accounts/bundles.py
+++ b/invenio_accounts/bundles.py
@@ -24,7 +24,7 @@ from __future__ import unicode_literals
 from invenio_base.bundles import invenio as _i
 from invenio_base.bundles import jquery as _j
 from invenio_base.bundles import styles as _styles
-from invenio.ext.assets import Bundle, RequireJSFilter
+from invenio_ext.assets import Bundle, RequireJSFilter
 
 # The underscore makes it "hidden" for the bundle collector.
 _styles.contents += ("css/accounts/login.css",)

--- a/invenio_accounts/forms.py
+++ b/invenio_accounts/forms.py
@@ -241,7 +241,7 @@ class ChangePasswordForm(InvenioBaseForm):
 
     def validate_current_password(self, field):
         """Validate current password."""
-        from invenio.ext.login import authenticate
+        from invenio_ext.login import authenticate
         if not authenticate(current_user['nickname'], field.data):
             raise validators.ValidationError(
                 _("Password mismatch."))

--- a/invenio_accounts/forms.py
+++ b/invenio_accounts/forms.py
@@ -31,7 +31,7 @@ from wtforms.validators import DataRequired, EqualTo, StopValidation, \
 
 from invenio_base.globals import cfg
 from invenio_base.i18n import _
-from invenio.utils.forms import InvenioBaseForm
+from invenio_utils.forms import InvenioBaseForm
 
 from .models import User
 from .validators import validate_email, validate_nickname, \

--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -24,9 +24,9 @@ import re
 from flask_login import current_user
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from invenio.ext.passlib import password_context
-from invenio.ext.passlib.hash import invenio_aes_encrypted_email
-from invenio.ext.sqlalchemy import db
+from invenio_ext.passlib import password_context
+from invenio_ext.passlib.hash import invenio_aes_encrypted_email
+from invenio_ext.sqlalchemy import db
 
 from .helpers import send_account_activation_email
 from .signals import profile_updated

--- a/invenio_accounts/upgrades/accounts_2015_01_14_add_name_columns.py
+++ b/invenio_accounts/upgrades/accounts_2015_01_14_add_name_columns.py
@@ -19,7 +19,7 @@
 
 """Add full name columns to User table."""
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 
 depends_on = [u'accounts_2014_11_07_usergroup_name_column_unique']

--- a/invenio_accounts/upgrades/accounts_2015_03_06_namedefaults.py
+++ b/invenio_accounts/upgrades/accounts_2015_03_06_namedefaults.py
@@ -20,7 +20,7 @@
 from sqlalchemy import *
 from sqlalchemy.dialects import mysql
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 
 depends_on = [u'accounts_2015_03_06_passlib',

--- a/invenio_accounts/upgrades/accounts_2015_03_06_passlib.py
+++ b/invenio_accounts/upgrades/accounts_2015_03_06_passlib.py
@@ -24,8 +24,8 @@ import hashlib
 from sqlalchemy import select
 from sqlalchemy.dialects import mysql
 
-from invenio.ext.passlib.hash import mysql_aes_encrypt
-from invenio.ext.sqlalchemy import db
+from invenio_ext.passlib.hash import mysql_aes_encrypt
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 
 depends_on = [u'accounts_2014_11_07_usergroup_name_column_unique']

--- a/invenio_accounts/upgrades/accounts_2015_06_26_userext.py
+++ b/invenio_accounts/upgrades/accounts_2015_06_26_userext.py
@@ -19,7 +19,7 @@
 
 """Change id column from VARBINARY to String."""
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 
 depends_on = [u'accounts_2015_03_06_passlib']

--- a/invenio_accounts/upgrades/accounts_2015_07_10_nickname_check_rules_changed.py
+++ b/invenio_accounts/upgrades/accounts_2015_07_10_nickname_check_rules_changed.py
@@ -19,7 +19,7 @@
 
 """Check if some of nicknames are not valid anymore."""
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 from invenio_accounts.models import User
 

--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -25,7 +25,7 @@ from flask import g, render_template, url_for
 
 from invenio_base.globals import cfg
 from invenio_base.i18n import _
-from invenio.ext.email import send_email
+from invenio_ext.email import send_email
 
 from .errors import AccountSecurityError
 from .tokens import EmailConfirmationSerializer

--- a/invenio_accounts/views/accounts.py
+++ b/invenio_accounts/views/accounts.py
@@ -36,10 +36,10 @@ from werkzeug.datastructures import CombinedMultiDict, ImmutableMultiDict
 from invenio_base.decorators import wash_arguments
 from invenio_base.globals import cfg
 from invenio_base.i18n import _
-from invenio.ext.login import UserInfo, authenticate, login_redirect, \
+from invenio_ext.login import UserInfo, authenticate, login_redirect, \
     login_user, logout_user
-from invenio.ext.sqlalchemy import db
-from invenio.ext.sslify import ssl_required
+from invenio_ext.sqlalchemy import db
+from invenio_ext.sslify import ssl_required
 from invenio.legacy import webuser
 from invenio.utils.datastructures import LazyDict, flatten_multidict
 
@@ -224,7 +224,7 @@ def index():
 
     if current_user.is_super_admin:
         # Check for a new release of Invenio
-        from invenio.ext.script import check_for_software_updates
+        from invenio_ext.script import check_for_software_updates
         check_for_software_updates(flash_message=True)
 
     if dashboard_settings:

--- a/invenio_accounts/views/accounts.py
+++ b/invenio_accounts/views/accounts.py
@@ -41,7 +41,7 @@ from invenio_ext.login import UserInfo, authenticate, login_redirect, \
 from invenio_ext.sqlalchemy import db
 from invenio_ext.sslify import ssl_required
 from invenio.legacy import webuser
-from invenio.utils.datastructures import LazyDict, flatten_multidict
+from invenio_utils.datastructures import LazyDict, flatten_multidict
 
 from ..errors import AccountSecurityError
 from ..forms import LoginForm, LostPasswordForm, RegisterForm, \
@@ -247,7 +247,7 @@ def index():
         plugins = [plugins_left, plugins_middle, plugins_right]
     else:
         plugins = sorted(plugins, key=lambda w: plugin_sort(w, plugins))
-        plugins = [plugins[i:i+3] for i in range(0, len(plugins), 3)]
+        plugins = [plugins[i:i + 3] for i in range(0, len(plugins), 3)]
     return render_template('accounts/index.html',
                            plugins=plugins, closed_plugins=closed_plugins)
 

--- a/invenio_accounts/views/settings.py
+++ b/invenio_accounts/views/settings.py
@@ -27,8 +27,8 @@ from flask_login import current_user, login_required
 from flask_menu import current_menu, register_menu
 
 from invenio_base.i18n import _
-from invenio.ext.sqlalchemy import db
-from invenio.ext.sslify import ssl_required
+from invenio_ext.sqlalchemy import db
+from invenio_ext.sslify import ssl_required
 
 from ..errors import AccountSecurityError
 from ..forms import ChangePasswordForm, LostPasswordForm, ProfileForm, \

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_accounts --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_accounts --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,6 +29,8 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
 -e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
+-e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,4 +29,6 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
+

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ test_requirements = [
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
     'unittest2>=1.1.0',
+    'invenio-testing>=0.1.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ requirements = [
 
 test_requirements = [
     'Flask-Testing>=0.4.1',
-    'coverage>=3.7.1',
-    'pytest-cov>=1.8.1',
+    'coverage>=4.0.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.7.0',
+    'pytest>=2.8.0',
     'unittest2>=1.1.0',
 ]
 
@@ -80,9 +80,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ requirements = [
     'cryptography>=0.6',
     'itsdangerous>=0.24',
     'invenio-base>=0.2.1',
+    'invenio-ext>=0.1.0',
+    'invenio-utils>=0.1.0',
     'invenio-upgrader>=0.1.0',
 ]
 

--- a/tests/test_accounts_user.py
+++ b/tests/test_accounts_user.py
@@ -19,7 +19,7 @@
 
 """Unit tests for the user handling library."""
 
-from invenio.testsuite import InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 
 class UserTestCase(InvenioTestCase):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -78,7 +78,7 @@ class FormsTestCase(InvenioTestCase):
         """Test ProfileForm nickname."""
         from invenio_accounts.forms import ProfileForm
         from flask_login import login_user, logout_user
-        from invenio.ext.login import UserInfo
+        from invenio_ext.login import UserInfo
 
         form = ProfileForm(
             nickname=self.nickname,
@@ -322,7 +322,7 @@ class FormsTestCase(InvenioTestCase):
         """Test ChangePasswordForm current password."""
         from invenio_accounts.forms import ChangePasswordForm
         from flask_login import login_user, logout_user
-        from invenio.ext.login import UserInfo
+        from invenio_ext.login import UserInfo
 
         valid_pwd = "x" * self.min_len
 
@@ -353,7 +353,7 @@ class FormsTestCase(InvenioTestCase):
         """Test ChangePasswordForm password."""
         from invenio_accounts.forms import ChangePasswordForm
         from flask_login import login_user, logout_user
-        from invenio.ext.login import UserInfo
+        from invenio_ext.login import UserInfo
 
         not_valid_pwd = "x" * (self.min_len - 1)
         valid_pwd = "x" * self.min_len

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -21,7 +21,7 @@
 
 from flask import current_app
 
-from invenio.testsuite import InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 
 class FormsTestCase(InvenioTestCase):
@@ -210,7 +210,7 @@ class FormsTestCase(InvenioTestCase):
         form = ProfileForm(
             nickname=self.nickname,
             email=self.email,
-            repeat_email=self.email+'fuu',
+            repeat_email=self.email + 'fuu',
         )
         assert form.validate() is False
 
@@ -314,7 +314,7 @@ class FormsTestCase(InvenioTestCase):
 
         form = ResetPasswordForm(
             password=self.password,
-            password2=self.password+"different"
+            password2=self.password + "different"
         )
         assert form.validate() is False
 
@@ -376,7 +376,7 @@ class FormsTestCase(InvenioTestCase):
         form = ChangePasswordForm(
             current_password=self.password,
             password=valid_pwd,
-            password2=valid_pwd+'different'
+            password2=valid_pwd + 'different'
         )
         assert form.validate() is False
 
@@ -539,6 +539,6 @@ class FormsTestCase(InvenioTestCase):
             email="valid@email.it",
             nickname="testvalidnickname",
             password=valid_pwd,
-            password2=valid_pwd+"different"
+            password2=valid_pwd + "different"
         )
         assert form.validate() is False

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 
 from itsdangerous import SignatureExpired
 
-from invenio.testsuite import InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 from invenio_accounts.tokens import EmailConfirmationSerializer
 


### PR DESCRIPTION
* FIX pytest 2.8.0 removed functionality used for tests. This removes
  calls to the removed functions.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>