### PR TITLE
accounts: invenio-theme for example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 target/
 
 examples/instance/
+examples/static/

--- a/examples/app.py
+++ b/examples/app.py
@@ -23,13 +23,29 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
-"""Minimal Flask application example for development.
+u"""Minimal Flask application example for development.
+
+Install the Invenio default theme
+
+You should execute these commands in the examples-directory.
+
+.. code-block:: console
+
+   $ pip install -e \
+   git+https://github.com/inveniosoftware/invenio-theme.git#egg=invenio-theme
+   $ pip install -e \
+   git+https://github.com/inveniosoftware/invenio-assets.git#egg=invenio-assets
+   $ flask -a app.py bower
+   $ cd instance
+   $ bower install
+   $ cd ..
+   $ flask -a app.py collect -v
+   $ flask -a app.py assets build
 
 Create database and tables:
 
 .. code-block:: console
 
-   $ cd examples
    $ flask -a app.py db init
    $ flask -a app.py db create
 
@@ -42,6 +58,8 @@ Create a user:
 
 Run the development server:
 
+.. code-block:: console
+
    $ flask -a app.py --debug run --debugger
    $ flask -a app.py shell
 """
@@ -49,13 +67,34 @@ Run the development server:
 from __future__ import absolute_import, print_function
 
 from flask import Flask, render_template
+
 from flask_babelex import Babel
+
 from flask_cli import FlaskCLI
+
 from flask_mail import Mail
+
 from flask_security import current_user
-from invenio_db import InvenioDB
 
 from invenio_accounts import InvenioAccounts
+
+from invenio_db import InvenioDB
+
+import pkg_resources
+
+try:
+    pkg_resources.get_distribution('invenio_assets')
+    from invenio_assets import InvenioAssets
+    INVENIO_ASSETS_AVAILABLE = True
+except pkg_resources.DistributionNotFound:
+    INVENIO_ASSETS_AVAILABLE = False
+
+try:
+    pkg_resources.get_distribution('invenio_theme')
+    from invenio_theme import InvenioTheme
+    INVENIO_THEME_AVAILABLE = True
+except pkg_resources.DistributionNotFound:
+    INVENIO_THEME_AVAILABLE = False
 
 # Create Flask application
 app = Flask(__name__)
@@ -73,6 +112,10 @@ FlaskCLI(app)
 Babel(app)
 Mail(app)
 InvenioDB(app)
+if INVENIO_ASSETS_AVAILABLE:
+    InvenioAssets(app)
+if INVENIO_THEME_AVAILABLE:
+    InvenioTheme(app)
 InvenioAccounts(app)
 
 

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -82,6 +82,10 @@ class InvenioAccounts(object):
             app.config.get("COVER_TEMPLATE",
                            "invenio_accounts/base_cover.html"))
         app.config.setdefault(
+            "ACCOUNTS_SETTINGS_TEMPLATE",
+            app.config.get("SETTINGS_TEMPLATE",
+                           "invenio_accounts/settings/base.html"))
+        app.config.setdefault(
             "ACCOUNTS_SITENAME",
             app.config.get("THEME_SITENAME", "Invenio"))
         app.config.setdefault("ACCOUNTS_USE_CELERY", True)

--- a/invenio_accounts/templates/invenio_accounts/change_password.html
+++ b/invenio_accounts/templates/invenio_accounts/change_password.html
@@ -22,8 +22,34 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
-{%- extends config.ACCOUNTS_BASE_TEMPLATE %}
+{%- extends config.ACCOUNTS_SETTINGS_TEMPLATE %}
 
-{% block page_body %}
-{% include "security/change_password.html" %}
-{% endblock %}
+{% from "invenio_accounts/_macros.html" import render_field, form_errors %}
+
+{% block settings_form %}
+{%- with form = change_password_form %}
+
+<form action="{{ url_for_security('change_password') }}" method="POST" name="change_password_form">
+{{form_errors(form)}}
+{{form.hidden_tag()}}
+<div class="form-group"> 
+    <label class="control-label" for="password">{{_('Current password')}}</label>
+    {{ render_field(form.password, autofocus=True, errormsg=False) }}
+</div>
+<div class="form-group"> 
+    <label class="control-label" for="new_password">{{_('New password')}}</label>
+    {{ render_field(form.new_password, errormsg=False) }}
+</div>
+<div class="form-group"> 
+    <label class="control-label" for="new_password_confirm">{{_('Confirm new password')}}</label>
+    {{ render_field(form.new_password_confirm, errormsg=False) }}
+</div>
+<div class="form-actions">
+    <button type="submit" class="btn btn-primary">{{_('Change Password')}}</button>
+    <a href="{{url_for_security('forgot_password')}}" style="margin-left: 15px"
+        <small>{{ _('Lost password?') }}</small>
+    </a>
+</div>
+</form>
+{%- endwith %}
+{% endblock settings_form %}

--- a/invenio_accounts/templates/invenio_accounts/forgot_password.html
+++ b/invenio_accounts/templates/invenio_accounts/forgot_password.html
@@ -27,12 +27,13 @@
 {% from "invenio_accounts/_macros.html" import render_field, form_errors %}
 {%- set messages = get_flashed_messages(with_categories=true) -%}
 
-{% block panel %}
+{% block page_body %}
 {%- with form = forgot_password_form %}
 <div class="col-md-6 col-md-offset-3">
+  <h1 class="text-center">{{ config.ACCOUNTS_SITENAME }}</h1>
   <div class="panel panel-default">
     <div class="panel-body">
-      <h3 class="text-center panel-free-title">{{_('Reset password')}}</h3>
+      <h3 class="text-center panel-free-title">{{_('Reset Password')}}</h3>
       {%- if messages %}
       {%- for category, message in messages %}
         <p>{{ message }}</p>
@@ -42,7 +43,7 @@
       <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
       {{ form.hidden_tag() }}
       {{ render_field(form.email, icon="glyphicon glyphicon-user", autofocus=True) }}
-      <button type="submit" class="btn btn-primary btn-lg btn-block">{{_('Reset password')}}</button>
+      <button type="submit" class="btn btn-primary btn-lg btn-block">{{_('Reset Password')}}</button>
       </form>
       {%- endif %}
     </div>
@@ -52,4 +53,4 @@
   </div>
 </div>
 {%- endwith %}
-{% endblock panel %}
+{% endblock page_body %}

--- a/invenio_accounts/templates/invenio_accounts/forgot_password.html
+++ b/invenio_accounts/templates/invenio_accounts/forgot_password.html
@@ -39,7 +39,7 @@
       {%- endfor %}
       {%- else %}
       <p class="text-left">{{_('Enter your email address below and we will send you a link to reset your password.')}}</p>
-      <form actio="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
+      <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
       {{ form.hidden_tag() }}
       {{ render_field(form.email, icon="glyphicon glyphicon-user", autofocus=True) }}
       <button type="submit" class="btn btn-primary btn-lg btn-block">{{_('Reset password')}}</button>

--- a/invenio_accounts/templates/invenio_accounts/login_user.html
+++ b/invenio_accounts/templates/invenio_accounts/login_user.html
@@ -32,7 +32,7 @@
   <div class="panel panel-default">
     <div class="panel-body">
       <h3 class="text-center panel-free-title">{{_('Log in to account')}}</h3>
-      <form actio="{{ url_for_security('login') }}" method="POST" name="login_user_form">
+      <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
       {{form.hidden_tag()}}
       {{form_errors(form)}}
       {{ render_field(form.email, icon="glyphicon glyphicon-user", autofocus=True, errormsg=False) }}

--- a/invenio_accounts/templates/invenio_accounts/login_user.html
+++ b/invenio_accounts/templates/invenio_accounts/login_user.html
@@ -26,12 +26,14 @@
 
 {% from "invenio_accounts/_macros.html" import render_field, form_errors %}
 
-{% block panel %}
+{% block cover_body %}
+
 {%- with form = login_user_form %}
 <div class="col-md-6 col-md-offset-3">
+  <h1 class="text-center">{{config.ACCOUNTS_SITENAME}}</h1>
   <div class="panel panel-default">
     <div class="panel-body">
-      <h3 class="text-center panel-free-title">{{_('Log in to account')}}</h3>
+      <h3 class="text-center panel-free-title">{{_('Log in to account') }}</h3>
       <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
       {{form.hidden_tag()}}
       {{form_errors(form)}}
@@ -51,4 +53,4 @@
   {%- endif %}
 </div>
 {%- endwith %}
-{% endblock panel %}
+{% endblock cover_body %}

--- a/invenio_accounts/templates/invenio_accounts/register_user.html
+++ b/invenio_accounts/templates/invenio_accounts/register_user.html
@@ -26,9 +26,10 @@
 
 {% from "invenio_accounts/_macros.html" import render_field, form_errors %}
 
-{% block panel %}
+{% block cover_body %}
 {%- with form = register_user_form %}
 <div class="col-md-6 col-md-offset-3">
+  <h1 class="text-center">{{config.ACCOUNTS_SITENAME}}</h1>
   <div class="panel panel-default">
     <div class="panel-body">
       <h3 class="text-center panel-free-title">{% trans sitename=config.ACCOUNTS_SITENAME %}Sign up for {{sitename}} account!{% endtrans %}</h3>
@@ -43,7 +44,7 @@
       {%- if form.recaptcha %}
         <div class="form-group form-group-lg">{{ form.recaptcha() }}</div>
       {%- endif %}
-      <button type="submit" class="btn btn-warning btn-lg btn-block"><i class="fa fa-edit"></i> {{_('Sign Up')}}</button>
+      <button type="submit" class="btn btn-primary btn-lg btn-block"><i class="fa fa-edit"></i> {{_('Sign Up')}}</button>
       </form>
     </div>
     <div class="panel-footer text-center">
@@ -55,4 +56,4 @@
   </div>
 </div>
 {%- endwith %}
-{% endblock panel %}
+{% endblock cover_body %}

--- a/invenio_accounts/templates/invenio_accounts/send_confirmation.html
+++ b/invenio_accounts/templates/invenio_accounts/send_confirmation.html
@@ -22,10 +22,26 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
-{%- extends config.ACCOUNTS_BASE_TEMPLATE %}
+{%- extends config.ACCOUNTS_COVER_TEMPLATE %}
 
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "invenio_accounts/_macros.html" import render_field, form_errors %}
 
-{% block content %}
-{% include "security/send_confirmation.html" %}
-{% endblock %}
+{% block cover_body %}
+{%- with form = send_confirmation_form %}
+<div class="col-md-6 col-md-offset-3">
+  <h1 class="text-center">{{config.ACCOUNTS_SITENAME}}</h1>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <h3 class="text-center panel-free-title">{{_('Resend Confirmation Email')}}</h3>
+      <p class="text-left">{{_('Enter your email address below and we will send you an email confirmation link.')}}</p>
+      <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
+      {{form.hidden_tag()}}
+      {{form_errors(form)}}
+      {{ render_field(form.email, icon="glyphicon glyphicon-user", autofocus=True, errormsg=False) }}
+      <button type="submit" class="btn btn-primary btn-lg btn-block"><i class="fa fa-sign-in"></i> {{_('Send Confirmation')}}</button>
+      </form>
+    </div>
+  </div>
+</div>
+{%- endwith %}
+{% endblock cover_body %}

--- a/invenio_accounts/templates/invenio_accounts/settings/base.html
+++ b/invenio_accounts/templates/invenio_accounts/settings/base.html
@@ -22,9 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
-{%- extends config.ACCOUNTS_COVER_TEMPLATE %}
+{%- extends "invenio_accounts/base.html" %}
 
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
-
-{% block cover_body %}
-{% endblock cover_body %}
+{%- block page_body %}
+{%- block settings_form %}{%- endblock settings_form %}
+{%- endblock page_body %}

--- a/invenio_accounts/views.py
+++ b/invenio_accounts/views.py
@@ -28,9 +28,29 @@ from __future__ import absolute_import, print_function
 
 from flask import Blueprint
 
+from flask_babelex import gettext as _
+
+from flask_menu import register_menu
+
 blueprint = Blueprint(
     'invenio_accounts',
     __name__,
     template_folder='templates',
     static_folder='static',
 )
+
+
+# Register menus
+@register_menu(blueprint, 'settings.account', _('Account'),
+               active_when=lambda: False)
+def _menu_header():
+    pass
+
+
+@blueprint.route('/change')
+@register_menu(blueprint, 'settings.account.change_password',
+               _('%(icon)s Change Password',
+                 icon='<i class="fa fa-key fa-fw"></i>'))
+def change_password():
+    """Register menu route."""
+    return

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ install_requires = [
     'Flask-Login>=0.2.11,<0.3.0',
     'Flask-Script>=2.0.5',
     'Flask-Security>=1.7.4',
+    'invenio-base>=0.3.1',
     'invenio-db>=1.0.0a1',
     'SQLAlchemy-Utils[ipaddress]>=0.31.0',
 ]
@@ -77,6 +78,7 @@ packages = find_packages()
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -31,6 +31,7 @@ from flask import Flask
 from flask_babelex import Babel
 from flask_cli import FlaskCLI
 from flask_mail import Mail
+from flask_menu import Menu
 from invenio_db import InvenioDB
 
 from invenio_accounts import InvenioAccounts
@@ -111,6 +112,7 @@ def test_datastore_assignrole(app):
 
 def test_view(app):
     """Test view."""
+    Menu(app)
     InvenioAccounts(app)
     with app.test_client() as client:
         res = client.get("/login")


### PR DESCRIPTION
accounts: invenio-theme for example app

* Enables invenio-theme for the invenio-accounts example app.

* Adds examples/static/ to .gitignore.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>