### PR TITLE
global: fix ACCOUNTS_USE_CELERY behaviour

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Invenio user management and authentication.
 - Henning Weiler <henning.weiler@cern.ch>
 - Jan Aage Lavik <jan.age.lavik@cern.ch>
 - Javier Martin Montull <javier.martin.montull@cern.ch>
+- Javier Delgado Fernandez <javier.delgado.fernandez@cern.ch>
 - Jerome Caffaro <jerome.caffaro@cern.ch>
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Joaquim Rodrigues Silvestre <joaquim.rodrigues.silvestre@cern.ch>

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -33,6 +33,8 @@ from .cli import accounts as accounts_cli
 from .models import Role, User
 from .views import blueprint
 
+import pkg_resources
+
 
 class InvenioAccounts(object):
     """Invenio-Accounts extension."""
@@ -82,7 +84,11 @@ class InvenioAccounts(object):
         app.config.setdefault(
             "ACCOUNTS_SITENAME",
             app.config.get("THEME_SITENAME", "Invenio"))
-        app.config.setdefault("ACCOUNTS_USE_CELERY", True)
+        try:
+            pkg_resources.get_distribution('celery')
+            app.config.setdefault("ACCOUNTS_USE_CELERY", True)
+        except pkg_resources.DistributionNotFound:
+            app.config.setdefault("ACCOUNTS_USE_CELERY", False)
 
         # Change Flask-Security defaults
         app.config.setdefault('SECURITY_CHANGEABLE', True)


### PR DESCRIPTION
* Enables the use of Celery during the Invenio-Accounts
  extension configuration only if Celery is available in the
  system installation. (Closes #27)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>