### PR TITLE
cli: changed commands to flat structure

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Invenio user management and authentication.
 - Henning Weiler <henning.weiler@cern.ch>
 - Jan Aage Lavik <jan.age.lavik@cern.ch>
 - Javier Martin Montull <javier.martin.montull@cern.ch>
+- Javier Delgado Fernandez <javier.delgado.fernandez@cern.ch>
 - Jerome Caffaro <jerome.caffaro@cern.ch>
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Joaquim Rodrigues Silvestre <joaquim.rodrigues.silvestre@cern.ch>

--- a/examples/app.py
+++ b/examples/app.py
@@ -37,8 +37,8 @@ Create a user:
 
 .. code-block:: console
 
-   $ flask -a app.py accounts users create -e info@invenio-software.org -a
-   $ flask -a app.py accounts users activate -u info@invenio-software.org
+   $ flask -a app.py accounts usercreate -e info@invenio-software.org -a
+   $ flask -a app.py accounts useractivate -u info@invenio-software.org
 
 Run the development server:
 

--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -54,23 +54,13 @@ def accounts():
     """Account commands."""
 
 
-@accounts.group()
-def users():
-    """User related commands."""
-
-
-@accounts.group()
-def roles():
-    """Role related commands."""
-
-
-@users.command(name='create')
+@accounts.command()
 @click.option('-e', '--email', default=None)
 @click.password_option()
 @click.option('-a', '--active', default=False, is_flag=True)
 @with_appcontext
 @commit
-def createuser(email, password, active):
+def usercreate(email, password, active):
     """Create a user."""
     kwargs = dict(email=email, password=password, active='y' if active else '')
 
@@ -87,12 +77,12 @@ def createuser(email, password, active):
         raise click.UsageError('Error creating user. %s' % form.errors)
 
 
-@roles.command(name='create')
+@accounts.command()
 @click.option('-n', '--name', default=None)
 @click.option('-d', '--description', default=None)
 @with_appcontext
 @commit
-def createrole(**kwargs):
+def rolecreate(**kwargs):
     """Create a role."""
     if not kwargs['name']:
         raise click.UsageError('ERROR: You must specify a role name.')
@@ -100,12 +90,12 @@ def createrole(**kwargs):
     click.secho('Role "%(name)s" created successfully.' % kwargs, fg='green')
 
 
-@roles.command()
+@accounts.command()
 @click.option('-u', '--user')
 @click.option('-r', '--role')
 @with_appcontext
 @commit
-def add(user, role):
+def roleadd(user, role):
     """Add user to role."""
     user, role = _datastore._prepare_role_modify_args(user, role)
     if user is None:
@@ -119,12 +109,12 @@ def add(user, role):
         raise click.UsageError('Cannot add role to user.')
 
 
-@roles.command()
+@accounts.command()
 @click.option('-u', '--user')
 @click.option('-r', '--role')
 @with_appcontext
 @commit
-def remove(user, role):
+def roleremove(user, role):
     """Remove user from role."""
     user, role = _datastore._prepare_role_modify_args(user, role)
     if user is None:
@@ -138,11 +128,11 @@ def remove(user, role):
         raise click.UsageError('Cannot remove role from user.')
 
 
-@users.command()
+@accounts.command()
 @click.option('-u', '--user')
 @with_appcontext
 @commit
-def activate(user):
+def useractivate(user):
     """Activate a user."""
     user_obj = _datastore.get_user(user)
     if user_obj is None:
@@ -153,11 +143,11 @@ def activate(user):
         click.secho('User "%s" was already activated.' % user, fg='yellow')
 
 
-@users.command()
+@accounts.command()
 @click.option('-u', '--user')
 @with_appcontext
 @commit
-def deactivate(user):
+def userdeactivate(user):
     """Deactivate a user."""
     user_obj = _datastore.get_user(user)
     if user_obj is None:

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -33,6 +33,8 @@ from .cli import accounts as accounts_cli
 from .models import Role, User
 from .views import blueprint
 
+import pkg_resources
+
 
 class InvenioAccounts(object):
     """Invenio-Accounts extension."""
@@ -82,7 +84,11 @@ class InvenioAccounts(object):
         app.config.setdefault(
             "ACCOUNTS_SITENAME",
             app.config.get("THEME_SITENAME", "Invenio"))
-        app.config.setdefault("ACCOUNTS_USE_CELERY", True)
+        try:
+            pkg_resources.get_distribution('celery')
+            app.config.setdefault("ACCOUNTS_USE_CELERY", True)
+        except pkg_resources.DistributionNotFound:
+            app.config.setdefault("ACCOUNTS_USE_CELERY", False)
 
         # Change Flask-Security defaults
         app.config.setdefault('SECURITY_CHANGEABLE', True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,8 +29,8 @@ from __future__ import absolute_import, print_function
 
 from click.testing import CliRunner
 
-from invenio_accounts.cli import activate, add, createrole, createuser, \
-    deactivate, remove
+from invenio_accounts.cli import roleadd, rolecreate, roleremove, \
+    useractivate, usercreate, userdeactivate
 
 
 def test_cli_createuser(script_info):
@@ -39,12 +39,12 @@ def test_cli_createuser(script_info):
 
     # Missing params
     result = runner.invoke(
-        createuser, input='1234\n1234\n', obj=script_info)
+        usercreate, input='1234\n1234\n', obj=script_info)
     assert result.exit_code != 0
 
     # Create user
     result = runner.invoke(
-        createuser,
+        usercreate,
         ['-e', 'info@invenio-software.org', '--password', '123456'],
         obj=script_info
     )
@@ -57,13 +57,13 @@ def test_cli_createrole(script_info):
 
     # Missing params
     result = runner.invoke(
-        createrole, ['-d', 'Test description'],
+        rolecreate, ['-d', 'Test description'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Create role
     result = runner.invoke(
-        createrole,
+        rolecreate,
         ['-n', 'superusers', '-d', 'Test description'],
         obj=script_info)
     assert result.exit_code == 0
@@ -75,58 +75,58 @@ def test_cli_addremove_role(script_info):
 
     # Create a user and a role
     result = runner.invoke(
-        createuser,
+        usercreate,
         ['-e', 'a@example.org', '--password', '123456'],
         obj=script_info
     )
     assert result.exit_code == 0
-    result = runner.invoke(createrole, ['-n', 'superuser'], obj=script_info)
+    result = runner.invoke(rolecreate, ['-n', 'superuser'], obj=script_info)
     assert result.exit_code == 0
 
     # User not found
     result = runner.invoke(
-        add, ['-u', 'inval@example.org', '-r', 'superuser'],
+        roleadd, ['-u', 'inval@example.org', '-r', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Add:
     result = runner.invoke(
-        add, ['-u', 'a@example.org', '-r', 'invalid'],
+        roleadd, ['-u', 'a@example.org', '-r', 'invalid'],
         obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        remove, ['-u', 'inval@example.org', '-r', 'superuser'],
+        roleremove, ['-u', 'inval@example.org', '-r', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        remove, ['-u', 'a@example.org', '-r', 'invalid'],
+        roleremove, ['-u', 'a@example.org', '-r', 'invalid'],
         obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        remove, ['-u', 'b@example.org', '-r', 'superuser'],
+        roleremove, ['-u', 'b@example.org', '-r', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        remove, ['-u', 'a@example.org', '-r', 'superuser'],
+        roleremove, ['-u', 'a@example.org', '-r', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Add:
-    result = runner.invoke(add, ['-u', 'a@example.org', '-r', 'superuser'],
+    result = runner.invoke(roleadd, ['-u', 'a@example.org', '-r', 'superuser'],
                            obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(add, ['-u', 'a@example.org', '-r', 'superuser'],
+    result = runner.invoke(roleadd, ['-u', 'a@example.org', '-r', 'superuser'],
                            obj=script_info)
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        remove, ['-u', 'a@example.org', '-r', 'superuser'],
+        roleremove, ['-u', 'a@example.org', '-r', 'superuser'],
         obj=script_info)
     assert result.exit_code == 0
 
@@ -137,27 +137,31 @@ def test_cli_activate_deactivate(script_info):
 
     # Create a user
     result = runner.invoke(
-        createuser,
+        usercreate,
         ['-e', 'a@example.org', '--password', '123456'],
         obj=script_info
     )
     assert result.exit_code == 0
 
     # Activate
-    result = runner.invoke(activate, ['-u', 'in@valid.org'], obj=script_info)
+    result = runner.invoke(useractivate, ['-u', 'in@valid.org'],
+                           obj=script_info)
     assert result.exit_code != 0
-    result = runner.invoke(deactivate, ['-u', 'in@valid.org'], obj=script_info)
+    result = runner.invoke(userdeactivate, ['-u', 'in@valid.org'],
+                           obj=script_info)
     assert result.exit_code != 0
 
-    result = runner.invoke(activate, ['-u', 'a@example.org'], obj=script_info)
+    result = runner.invoke(useractivate, ['-u', 'a@example.org'],
+                           obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(activate, ['-u', 'a@example.org'], obj=script_info)
+    result = runner.invoke(useractivate, ['-u', 'a@example.org'],
+                           obj=script_info)
     assert result.exit_code == 0
 
     # Deactivate
-    result = runner.invoke(deactivate,
+    result = runner.invoke(userdeactivate,
                            ['-u', 'a@example.org'], obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(deactivate,
+    result = runner.invoke(userdeactivate,
                            ['-u', 'a@example.org'], obj=script_info)
     assert result.exit_code == 0


### PR DESCRIPTION
* The commands of CLI tool have been changed to use
  just a keyword instead of the two keywords used before.
  (Closes #29)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>