### PR TITLE
templates: reset form fix for logged in users

### DIFF
--- a/invenio_accounts/templates/invenio_accounts/change_password.html
+++ b/invenio_accounts/templates/invenio_accounts/change_password.html
@@ -45,9 +45,6 @@
 </div>
 <div class="form-actions">
     <button type="submit" class="btn btn-primary">{{_('Change Password')}}</button>
-    <a href="{{url_for_security('forgot_password')}}" style="margin-left: 15px"
-        <small>{{ _('Lost password?') }}</small>
-    </a>
 </div>
 </form>
 {%- endwith %}

--- a/invenio_accounts/templates/invenio_accounts/forgot_password.html
+++ b/invenio_accounts/templates/invenio_accounts/forgot_password.html
@@ -46,9 +46,13 @@
       </form>
       {%- endif %}
     </div>
+    
+    {# contents of this if-block can be always shown after mattupstate/flask-security#291 is released. #}
+    {%- if current_user.is_anonymous() %}
     <div class="panel-footer text-center">
         <h4 class="text-muted"><a href="{{url_for('security.login')}}">{{_('Log In')}}</a>{% if security.registerable %} or <a href="{{url_for('security.register')}}">{{_('Sign Up')}}</a>{% endif %}</h4>
     </div>
+    {%- endif %}
   </div>
 </div>
 {%- endwith %}

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,6 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+https://github.com/mattupstate/flask-security.git#egg=Flask-Security
+# inveniosoftware/invenio-accounts#41 -e git+https://github.com/mattupstate/flask-security.git#egg=Flask-Security
 -e git+https://github.com/inveniosoftware/invenio-db.git#egg=invenio-db
 -e git+https://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup_requires = [
 
 install_requires = [
     'Flask-BabelEx>=0.9.2',
-    'Flask-Login>=0.2.11,<0.3.0',
+    'Flask-Login<0.3.0,>=0.2.11',
     'Flask-Menu>=0.4.0',
     'Flask-Security>=1.7.4',
     'invenio-base>=1.0.0a1',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@
 
 from __future__ import absolute_import, print_function
 
+import os
 import shutil
 import tempfile
 
@@ -35,6 +36,7 @@ from flask import Flask
 from flask_babelex import Babel
 from flask_cli import FlaskCLI, ScriptInfo
 from flask_mail import Mail
+from flask_menu import Menu
 from invenio_db import InvenioDB, db
 
 from invenio_accounts import InvenioAccounts
@@ -53,10 +55,15 @@ def app(request):
         MAIL_SUPPRESS_SEND=True,
         SECRET_KEY="CHANGE_ME",
         SECURITY_PASSWORD_SALT="CHANGE_ME_ALSO",
-        SQLALCHEMY_DATABASE_URI='sqlite://',  # in memory db
+        SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
+                                          'sqlite://'),
         TESTING=True,
+        LOGIN_DISABLED=False,
+        WTF_CSRF_ENABLED=False,
+        SERVER_NAME='example.com',
     )
     FlaskCLI(app)
+    Menu(app)
     Babel(app)
     Mail(app)
     InvenioDB(app)

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -31,7 +31,6 @@ from flask import Flask
 from flask_babelex import Babel
 from flask_cli import FlaskCLI
 from flask_mail import Mail
-from flask_menu import Menu
 from invenio_db import InvenioDB
 
 from invenio_accounts import InvenioAccounts
@@ -113,7 +112,6 @@ def test_datastore_assignrole(app):
 
 def test_view(app):
     """Test view."""
-    Menu(app)
     InvenioAccounts(app)
     app.register_blueprint(blueprint)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+from flask_babelex import gettext as _
+from flask_security import url_for_security
+
+from invenio_accounts import InvenioAccounts
+from invenio_accounts.views import blueprint
+
+
+def test_no_log_in_message_for_logged_in_users(app):
+    """Test the password reset form for logged in users.
+
+    Password reset form should not show log in or sign up messages for logged
+    in users.
+    """
+    InvenioAccounts(app)
+    app.register_blueprint(blueprint)
+    with app.app_context():
+        with app.test_client() as client:
+            log_in_message = _('Log In').encode('utf-8')
+            sign_up_message = _('Sign Up').encode('utf-8')
+            forgot_password_url = url_for_security('forgot_password')
+
+            resp = client.get(forgot_password_url)
+            assert resp.status_code == 200
+            assert log_in_message in resp.data
+            assert sign_up_message in resp.data
+
+            test_email = 'info@invenio-software.org'
+            test_password = 'test1234'
+            resp = client.post(url_for_security('register'), data=dict(
+                email=test_email,
+                password=test_password,
+            ), environ_base={'REMOTE_ADDR': '127.0.0.1'})
+
+            resp = client.post(url_for_security('login'), data=dict(
+                email=test_email,
+                password=test_password,
+            ))
+
+            resp = client.get(forgot_password_url, follow_redirects=True)
+            if resp.status_code == 200:
+                # This behavior will be phased out in future Flask-Security
+                # release as per mattupstate/flask-security#291
+                assert log_in_message not in resp.data
+                assert sign_up_message not in resp.data
+            else:
+                # Future Flask-Security will redirect to post login view when
+                # authenticated user requests password reset page.
+                assert resp.data == client.get(
+                    app.config['SECURITY_POST_LOGIN_VIEW']).data


### PR DESCRIPTION
* Removes 'Log In or Sign Up' message from the password reset form for
  logged in users. (closes #35)

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>