### PR TITLE
i18n: addition of missing .pot file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
 
 # Django stuff:
 *.log

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -50,5 +50,5 @@ recursive-include docs Makefile
 recursive-include examples *.html
 recursive-include examples *.py
 recursive-include invenio_accounts *.html
-recursive-include invenio_accounts *.po
+recursive-include invenio_accounts *.po *.pot
 recursive-include tests *.py

--- a/invenio_accounts/translations/messages.pot
+++ b/invenio_accounts/translations/messages.pot
@@ -1,19 +1,18 @@
-# Danish translations for invenio-accounts.
+# Translations template for invenio-accounts.
 # Copyright (C) 2015 CERN
 # This file is distributed under the same license as the invenio-accounts
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-accounts 0.1.0.dev20150000\n"
+"Project-Id-Version: invenio-accounts 1.0.0a2\n"
 "Report-Msgid-Bugs-To: info@invenio-software.org\n"
-"POT-Creation-Date: 2015-11-10 15:53+0100\n"
-"PO-Revision-Date: 2015-10-13 17:58+0200\n"
+"POT-Creation-Date: 2015-11-10 15:55+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: da\n"
-"Language-Team: da <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -102,10 +101,4 @@ msgstr ""
 #: invenio_accounts/templates/invenio_accounts/send_confirmation.html:41
 msgid "Send Confirmation"
 msgstr ""
-
-#~ msgid "Reset password"
-#~ msgstr ""
-
-#~ msgid "G Invenio! Sign up for free today."
-#~ msgstr ""
 


### PR DESCRIPTION
* Adds missing .pot file to version control. (closes #24)

* Adds *.pot files to MANIFEST.in

* Removes *.pot from .gitignore

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen>