### PR TITLE
tests: e2e/integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,10 @@ install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
   - "travis_retry pip install -e .[${EXTRAS}]"
 
+before_script:
+  - "export DISPLAY=:99.0" #set up xvfb, req'd for non-phantomJS webdrivers
+  - "sh -e /etc/init.d/xvfb start"
+
 script:
   - "./run-tests.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ install:
 before_script:
   - "export DISPLAY=:99.0" #set up xvfb, req'd for non-phantomJS webdrivers
   - "sh -e /etc/init.d/xvfb start"
+  - "export E2E_WEBDRIVER_BROWSERS='Firefox'"
+  - "export E2E_WEBDRIVER_TIMEOUT='300'" # Max allowed time for E2E tests
 
 script:
   - "./run-tests.sh"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-# Check manifest will not automatically add these two files:
+# Check manifest will not automatically add these files:
 include .dockerignore
 include .editorconfig
 include .tx/config

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,3 +26,10 @@ Usage
 =====
 
 .. automodule:: invenio_accounts
+
+
+Test utilities
+--------------
+
+.. automodule:: invenio_accounts.testutils
+    :members:

--- a/invenio_accounts/testutils.py
+++ b/invenio_accounts/testutils.py
@@ -24,7 +24,7 @@
 
 """Invenio-Accounts utility functions for tests and testing purposes.
 
-DO NOT USE IN A PRODUCTION ENVIRONMENT.
+.. warning:: DO NOT USE IN A PRODUCTION ENVIRONMENT.
 
 Functions within accessing the datastore will throw an error if called outside
 of an application context. If pytest-flask is installed you don't have to worry
@@ -53,8 +53,6 @@ def create_test_user(email='test@test.org',
 
     Returns the created user model object instance, with the plaintext password
     as `user.password_plaintext`.
-
-    DO NOT USE THIS IN PRODUCTION. IT IS MEANT FOR TESTING PURPOSES ONLY.
     """
     assert flask.current_app.testing
     encrypted_password = encrypt_password(password)
@@ -88,3 +86,17 @@ def client_authenticated(client, test_url=None):
 
     return (response.status_code == 200 and
             not flask_login.current_user.is_anonymous)
+
+
+def webdriver_authenticated(webdriver, test_url=None):
+    """Attempt to get the change password page through the given webdriver.
+
+    Similar to `client_authenticated`, but for selenium webdriver objects.
+    """
+    save_url = webdriver.current_url
+
+    webdriver.get(test_url or flask.url_for('security.change_password',
+                                            _external=True))
+    result_url = webdriver.current_url
+    webdriver.get(save_url)
+    return (flask.url_for('security.login', _external=True) not in result_url)

--- a/invenio_accounts/testutils.py
+++ b/invenio_accounts/testutils.py
@@ -22,7 +22,14 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Invenio-Accounts utility functions for tests and testing purposes."""
+"""Invenio-Accounts utility functions for tests and testing purposes.
+
+DO NOT USE IN A PRODUCTION ENVIRONMENT.
+
+Functions within accessing the datastore will throw an error if called outside
+of an application context. If pytest-flask is installed you don't have to worry
+about this.
+"""
 
 from __future__ import absolute_import, print_function
 
@@ -41,8 +48,12 @@ def create_test_user(email='test@test.org',
                      password='123456', **kwargs):
     """Create a user in the datastore, bypassing the registration process.
 
+    Accesses the application's datastore. An error is thrown if called from
+    outside of an application context.
+
     Returns the created user model object instance, with the plaintext password
     as `user.password_plaintext`.
+
     DO NOT USE THIS IN PRODUCTION. IT IS MEANT FOR TESTING PURPOSES ONLY.
     """
     assert flask.current_app.testing

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ tests_require = [
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
     'pytest-flask>=0.10.0',
+    'selenium>=2.48.0',
     'Flask-CeleryExt>=0.1.0',
     'Flask-CLI>=0.2.1',
     'Flask-Mail>=0.9.1',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'pytest-flask>=0.10.0',
     'Flask-CeleryExt>=0.1.0',
     'Flask-CLI>=0.2.1',
     'Flask-Mail>=0.9.1',

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Pytest configuration."""
+
+from __future__ import absolute_import, print_function
+
+import os
+import shutil
+import tempfile
+
+import pytest
+from flask import Flask
+from flask_babelex import Babel
+from flask_cli import FlaskCLI
+from flask_mail import Mail
+from flask_menu import Menu
+from invenio_db import InvenioDB, db
+from selenium import webdriver
+from sqlalchemy_utils.functions import create_database, database_exists, \
+    drop_database
+
+from invenio_accounts import InvenioAccounts
+from invenio_accounts.views import blueprint
+
+
+@pytest.fixture()
+def app(request):
+    """Flask application fixture for E2E/integration/selenium tests.
+
+    Overrides the `app` fixture found in `../conftest.py`. Tests/files in
+    this folder and subfolders will see this variant of the `app` fixture.
+    """
+    instance_path = tempfile.mkdtemp()
+    app = Flask('testapp', instance_path=instance_path)
+    app.config.update(
+        ACCOUNTS_USE_CELERY=False,
+        CELERY_ALWAYS_EAGER=True,
+        CELERY_CACHE_BACKEND="memory",
+        CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+        CELERY_RESULT_BACKEND="cache",
+        MAIL_SUPPRESS_SEND=True,
+        SECRET_KEY="CHANGE_ME",
+        SECURITY_PASSWORD_SALT="CHANGE_ME_ALSO",
+        SQLALCHEMY_DATABASE_URI=os.environ.get(
+            'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'),
+        TESTING=True,
+        LOGIN_DISABLED=False,
+    )
+    FlaskCLI(app)
+    Menu(app)
+    Babel(app)
+    Mail(app)
+    InvenioDB(app)
+    InvenioAccounts(app)
+    app.register_blueprint(blueprint)
+
+    with app.app_context():
+        if not database_exists(str(db.engine.url)):
+            create_database(str(db.engine.url))
+        db.create_all()
+
+    def teardown():
+        with app.app_context():
+            drop_database(str(db.engine.url))
+        shutil.rmtree(instance_path)
+
+    request.addfinalizer(teardown)
+    return app
+
+
+@pytest.fixture()
+def ff_browser(request):
+    """Pytest fixture for a selenium/webdriver instance with Firefox."""
+    ff = webdriver.Firefox()
+    request.addfinalizer(lambda: ff.quit())
+    return ff

--- a/tests/e2e/e2e_basic_test.py
+++ b/tests/e2e/e2e_basic_test.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""E2E/integration tests for Invenio-Accounts."""
+
+from __future__ import absolute_import, print_function
+
+import sys
+import urllib
+
+import flask
+import pytest
+import six
+from six.moves.urllib.request import urlopen
+
+from invenio_accounts import testutils
+
+
+def test_live_server(live_server):
+    """Test that the login page of `live_server` is reachable.
+
+    The `live_server` fixture is provided by pytest-flask.
+    When a test using said fixture is run, the return object of the `app`
+    fixture is run in a background process.
+    For this test pytest will use the `app` fixture defined in `./conftest.py`
+    instead of the one in `../conftest.py`.
+    """
+    # With pytest-flask we don't need to be in the application context
+    # to use `flask.url_for`.
+    url = flask.url_for('security.login', _external=True)
+    response = urlopen(url)
+    assert response
+    assert response.code == 200
+
+
+def test_webdriver_not_authenticated(live_server, ff_browser):
+    """Test that an unauthenticated webdriver client is redirected from
+    the change password page to the login page."""
+    ff_browser.get(flask.url_for('security.change_password', _external=True))
+    assert (flask.url_for('security.login', _external=True) in
+            ff_browser.current_url)
+
+
+def test_user_registration(live_server, ff_browser):
+    """E2E user registration and login test."""
+    browser = ff_browser
+    # 1. Go to user registration page
+    browser.get(flask.url_for('security.register', _external=True))
+    assert (flask.url_for('security.register', _external=True) in
+            browser.current_url)
+    # 2. Input user data
+    signup_form = browser.find_element_by_name('register_user_form')
+    input_email = signup_form.find_element_by_name('email')
+    input_password = signup_form.find_element_by_name('password')
+    # input w/ name "email"
+    # input w/ name "password"
+    user_email = 'test@test.org'
+    user_password = '12345_SIx'
+    input_email.send_keys(user_email)
+    input_password.send_keys(user_password)
+
+    # 3. submit form
+    signup_form.submit()
+    # ...and get redirected to the "home page" ('/')
+    # This isn't a very important part of the process, and the '/' url isn't
+    # even registered for the Invenio-Accounts e2e app. So we don't check it.
+
+    # 3.5: After registering we should be logged in.
+    browser.get(flask.url_for('security.change_password', _external=True))
+    assert (flask.url_for('security.change_password', _external=True) in
+            browser.current_url)
+
+    # 3.5: logout.
+    browser.get(flask.url_for('security.logout', _external=True))
+    assert not testutils.webdriver_authenticated(browser)
+
+    # 4. go to login-form
+    browser.get(flask.url_for('security.login', _external=True))
+    assert (flask.url_for('security.login', _external=True) in
+            browser.current_url)
+    login_form = browser.find_element_by_name('login_user_form')
+    # 5. input registered info
+    login_form.find_element_by_name('email').send_keys(user_email)
+    login_form.find_element_by_name('password').send_keys(user_password)
+    # 6. Submit!
+    # check if authenticated at `flask.url_for('security.change_password')`
+    login_form.submit()
+
+    assert testutils.webdriver_authenticated(browser)
+
+    browser.get(flask.url_for('security.change_password', _external=True))
+    assert (flask.url_for('security.change_password', _external=True) in
+            browser.current_url)

--- a/tests/e2e/e2e_basic_test.py
+++ b/tests/e2e/e2e_basic_test.py
@@ -54,17 +54,18 @@ def test_live_server(live_server):
     assert response.code == 200
 
 
-def test_webdriver_not_authenticated(live_server, ff_browser):
+def test_webdriver_not_authenticated(live_server, env_browser):
     """Test that an unauthenticated webdriver client is redirected from
     the change password page to the login page."""
-    ff_browser.get(flask.url_for('security.change_password', _external=True))
+    browser = env_browser
+    browser.get(flask.url_for('security.change_password', _external=True))
     assert (flask.url_for('security.login', _external=True) in
-            ff_browser.current_url)
+            browser.current_url)
 
 
-def test_user_registration(live_server, ff_browser):
+def test_user_registration(live_server, env_browser):
     """E2E user registration and login test."""
-    browser = ff_browser
+    browser = env_browser
     # 1. Go to user registration page
     browser.get(flask.url_for('security.register', _external=True))
     assert (flask.url_for('security.register', _external=True) in

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,10 +28,12 @@
 from __future__ import absolute_import, print_function
 
 import flask_login
+import pkg_resources
 import pytest
 from flask_security import url_for_security
 from flask_security.utils import encrypt_password
 from invenio_db import db
+
 from invenio_accounts import InvenioAccounts, testutils
 from invenio_accounts.views import blueprint
 
@@ -54,7 +56,7 @@ def test_client_authenticated(app):
 
     with app.test_client() as client:
         # At this point we should not be authenticated/logged in as a user
-        assert not flask_login.current_user
+        assert flask_login.current_user.is_anonymous
         assert not testutils.client_authenticated(
             client, test_url=change_password_url)
 
@@ -78,7 +80,7 @@ def test_client_authenticated(app):
         response = client.post(login_url,
                                data={'email': email, 'password': password},
                                environ_base={'REMOTE_ADDR': '127.0.0.1'})
-        print(response.get_data(as_text=True))
+
         # Client gets redirected after logging in
         assert response.status_code == 302
         assert testutils.client_authenticated(client)
@@ -99,10 +101,6 @@ def test_create_test_user(app):
     ext = InvenioAccounts(app)
     email = 'test@test.org'
     password = '1234'
-
-    # Can't access the datastore outside of an application context
-    with pytest.raises(RuntimeError):
-        testutils.create_test_user(email, password)
 
     with app.app_context():
         user = testutils.create_test_user(email, password)


### PR DESCRIPTION
* Adds E2E/integration tests in `tests/e2e/`, and necessary changes to get them running locally and on Travis.
* Parametrizes the E2E tests via an environment variable and override of pytest's `pytest_generate_tests` in `tests/e2e/conftest.py`.
* Changes some existing tests to work with `pytest-flask`, which provides useful fixtures for e2e-testing.