### PR TITLE
WIP tests: session removal after user deactivation

### DIFF
--- a/invenio_accounts/sessions.py
+++ b/invenio_accounts/sessions.py
@@ -89,3 +89,15 @@ def delete_session(sid_s):
     _datastore.db.session.delete(sessionactivity)
     _datastore.commit()
     return 1
+
+
+def deactivate_user(user):
+    """Deactivates a user and invalidates (by deleting) their active sessions.
+
+    :param user: User to deactive.
+
+    :returns: True if user was successfully deactivated and their sessions
+        deleted. False if the user was already deactivated.
+    """
+    # TODO: delete user's active sessions
+    return _datastore.deactivate_user(user)


### PR DESCRIPTION
* addresses #44 
* Currently fails as the user's session is not invalidated upon said user's deactivation.
* Won't pass until #51 and #52 are taken care of