### PR TITLE
ext: celery use in debug mode change

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -72,7 +72,8 @@ class InvenioAccounts(object):
         """Initialize configuration."""
         try:
             pkg_resources.get_distribution('celery')
-            app.config.setdefault("ACCOUNTS_USE_CELERY", True)
+            app.config.setdefault(
+                "ACCOUNTS_USE_CELERY", not (app.debug or app.testing))
         except pkg_resources.DistributionNotFound:
             app.config.setdefault("ACCOUNTS_USE_CELERY", False)
 


### PR DESCRIPTION
Changes configuration to not use celery by default for sending email in debug and testing mode.

When you bootstrap a new site:

```console
$ inveniomanage instance create mysite
$ cd mysite
# mysite db init, db create, npm, npm install, collect, assets build
$ mysite --debug run
```

and afterwards go register a new account it will fail if you don't have rabbitmq running (like wise [this fix](https://github.com/inveniosoftware/invenio-base/commit/635498f37ddf339c595293aab4b7bf91fc5df9cb) ensures that the mail is printed to the console).

This only happens when ``--debug`` is specified and can be overwritten in the overlay config to always use celery.