### PR TITLE
tests: default user password fix

### DIFF
--- a/invenio_accounts/testutils.py
+++ b/invenio_accounts/testutils.py
@@ -38,7 +38,7 @@ _datastore = LocalProxy(lambda: current_app.extensions['security'].datastore)
 
 
 def create_test_user(email='test@test.org',
-                     password='', **kwargs):
+                     password='123456', **kwargs):
     """Create a user in the datastore, bypassing the registration process.
 
     Returns the created user model object instance, with the plaintext password

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,6 +124,20 @@ def test_create_test_user(app):
         # create a user with a duplicate email.
 
 
+def test_create_test_user_defaults(app):
+    """Test the default values for testutils.py:create_test_user."""
+
+    ext = InvenioAccounts(app)
+    app.register_blueprint(blueprint)
+
+    with app.app_context():
+        user = testutils.create_test_user()
+        with app.test_client() as client:
+            testutils.login_user_via_view(client, user.email,
+                                          user.password_plaintext)
+            assert testutils.client_authenticated(client)
+
+
 def test_login_user_via_view(app):
     """Test the login-via-view function/hack."""
     InvenioAccounts(app)


### PR DESCRIPTION
Passing no args to `testutils.py:create_test_user` created a user with the empty string as its password. Logging in doesn't work with such a user. This wasn't caught as all of the tests for `create_test_user` explicitly passed email and password.
The PR contains a test for the default values of `create_test_user`, and changes the default value of its `password` kwarg to a non-empty string.