### PR TITLE
templates: use fontawesome instead of glyphicons

### DIFF
--- a/invenio_accounts/templates/invenio_accounts/login_user.html
+++ b/invenio_accounts/templates/invenio_accounts/login_user.html
@@ -38,8 +38,8 @@
       <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
       {{form.hidden_tag()}}
       {{form_errors(form)}}
-      {{ render_field(form.email, icon="glyphicon glyphicon-user", autofocus=True, errormsg=False) }}
-      {{ render_field(form.password, icon="glyphicon glyphicon-lock", errormsg=False) }}
+      {{ render_field(form.email, icon="fa fa-user", autofocus=True, errormsg=False) }}
+      {{ render_field(form.password, icon="fa fa-lock", errormsg=False) }}
       <button type="submit" class="btn btn-primary btn-lg btn-block"><i class="fa fa-sign-in"></i> {{_('Log In')}}</button>
       </form>
       {%- endwith %}


### PR DESCRIPTION
* FIX Fixes CSS classes to use font awesome instead of glyphicons.

Signed-off-by: Eamonn Maguire <eamonnmag@gmail.com> 