### PR TITLE
templates: addition of a hook in login_user

### DIFF
--- a/invenio_accounts/templates/invenio_accounts/login_user.html
+++ b/invenio_accounts/templates/invenio_accounts/login_user.html
@@ -34,6 +34,7 @@
       <h3 class="text-center panel-free-title">{{_('Log in to account') }}</h3>
       {%- endblock form_header %}
       {%- block form_outer %}
+      {% block block_before_login_form %}{% endblock block_before_login_form %}
       {%- with form = login_user_form %}
       <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
       {{form.hidden_tag()}}


### PR DESCRIPTION
* Adds an empty block in login_user.html allowing the insertion of
  custom code before the login fields.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>