### PR TITLE
global: fix Message serialization for celery

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -60,7 +60,7 @@ class InvenioAccounts(object):
 
             @state.send_mail_task
             def delay_security_email(msg):
-                send_security_email.delay(msg)
+                send_security_email.delay(msg.__dict__)
 
         # Register CLI
         app.cli.add_command(roles_cli, 'roles')

--- a/invenio_accounts/tasks.py
+++ b/invenio_accounts/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -28,9 +28,12 @@ from __future__ import absolute_import, print_function
 
 from celery import shared_task
 from flask import current_app
+from flask_mail import Message
 
 
 @shared_task
-def send_security_email(msg):
+def send_security_email(data):
     """Celery task to send security email."""
+    msg = Message()
+    msg.__dict__.update(data)
     current_app.extensions['mail'].send(msg)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -40,7 +40,7 @@ def test_send_message_outbox(task_app):
                           sender='test1@test1.test1',
                           recipients=['test1@test1.test1'])
 
-            send_security_email(msg)
+            send_security_email(msg.__dict__)
 
             assert len(outbox) == 1
             sent_msg = outbox[0]


### PR DESCRIPTION
* Fixes default serializer of task sending Flask-Mail messages.
  (closes #81)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>