### PR TITLE
cli: unify arguments and options

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -51,8 +51,8 @@ Create a user:
 
 .. code-block:: console
 
-   $ flask -a app.py users create -e info@invenio-software.org -a
-   $ flask -a app.py users activate -u info@invenio-software.org
+   $ flask -a app.py users create info@invenio-software.org -a
+   $ flask -a app.py users activate info@invenio-software.org
 
 Run the development server:
 

--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -59,7 +59,7 @@ def roles():
 
 
 @users.command('create')
-@click.option('-e', '--email', default=None)
+@click.argument('email')
 @click.password_option()
 @click.option('-a', '--active', default=False, is_flag=True)
 @with_appcontext
@@ -82,21 +82,19 @@ def users_create(email, password, active):
 
 
 @roles.command('create')
-@click.option('-n', '--name', default=None)
+@click.argument('name')
 @click.option('-d', '--description', default=None)
 @with_appcontext
 @commit
 def roles_create(**kwargs):
     """Create a role."""
-    if not kwargs['name']:
-        raise click.UsageError('ERROR: You must specify a role name.')
     _datastore.create_role(**kwargs)
     click.secho('Role "%(name)s" created successfully.' % kwargs, fg='green')
 
 
 @roles.command('add')
-@click.option('-u', '--user')
-@click.option('-r', '--role')
+@click.argument('user')
+@click.argument('role')
 @with_appcontext
 @commit
 def roles_add(user, role):
@@ -114,8 +112,8 @@ def roles_add(user, role):
 
 
 @roles.command('remove')
-@click.option('-u', '--user')
-@click.option('-r', '--role')
+@click.argument('user')
+@click.argument('role')
 @with_appcontext
 @commit
 def roles_remove(user, role):
@@ -133,7 +131,7 @@ def roles_remove(user, role):
 
 
 @users.command('activate')
-@click.option('-u', '--user')
+@click.argument('user')
 @with_appcontext
 @commit
 def users_activate(user):
@@ -148,7 +146,7 @@ def users_activate(user):
 
 
 @users.command('deactivate')
-@click.option('-u', '--user')
+@click.argument('user')
 @with_appcontext
 @commit
 def users_deactivate(user):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,7 @@ def test_cli_createuser(script_info):
     # Create user
     result = runner.invoke(
         users_create,
-        ['-e', 'info@invenio-software.org', '--password', '123456'],
+        ['info@invenio-software.org', '--password', '123456'],
         obj=script_info
     )
     assert result.exit_code == 0
@@ -64,7 +64,7 @@ def test_cli_createrole(script_info):
     # Create role
     result = runner.invoke(
         roles_create,
-        ['-n', 'superusers', '-d', 'Test description'],
+        ['superusers', '-d', 'Test description'],
         obj=script_info)
     assert result.exit_code == 0
 
@@ -76,60 +76,60 @@ def test_cli_addremove_role(script_info):
     # Create a user and a role
     result = runner.invoke(
         users_create,
-        ['-e', 'a@example.org', '--password', '123456'],
+        ['a@example.org', '--password', '123456'],
         obj=script_info
     )
     assert result.exit_code == 0
-    result = runner.invoke(roles_create, ['-n', 'superuser'], obj=script_info)
+    result = runner.invoke(roles_create, ['superuser'], obj=script_info)
     assert result.exit_code == 0
 
     # User not found
     result = runner.invoke(
-        roles_add, ['-u', 'inval@example.org', '-r', 'superuser'],
+        roles_add, ['inval@example.org', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Add:
     result = runner.invoke(
-        roles_add, ['-u', 'a@example.org', '-r', 'invalid'],
+        roles_add, ['a@example.org', 'invalid'],
         obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ['-u', 'inval@example.org', '-r', 'superuser'],
+        roles_remove, ['inval@example.org', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        roles_remove, ['-u', 'a@example.org', '-r', 'invalid'],
+        roles_remove, ['a@example.org', 'invalid'],
         obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ['-u', 'b@example.org', '-r', 'superuser'],
+        roles_remove, ['b@example.org', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ['-u', 'a@example.org', '-r', 'superuser'],
+        roles_remove, ['a@example.org', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Add:
     result = runner.invoke(roles_add,
-                           ['-u', 'a@example.org', '-r', 'superuser'],
+                           ['a@example.org', 'superuser'],
                            obj=script_info)
     assert result.exit_code == 0
     result = runner.invoke(
         roles_add,
-        ['-u', 'a@example.org', '-r', 'superuser'],
+        ['a@example.org', 'superuser'],
         obj=script_info)
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        roles_remove, ['-u', 'a@example.org', '-r', 'superuser'],
+        roles_remove, ['a@example.org', 'superuser'],
         obj=script_info)
     assert result.exit_code == 0
 
@@ -141,30 +141,30 @@ def test_cli_activate_deactivate(script_info):
     # Create a user
     result = runner.invoke(
         users_create,
-        ['-e', 'a@example.org', '--password', '123456'],
+        ['a@example.org', '--password', '123456'],
         obj=script_info
     )
     assert result.exit_code == 0
 
     # Activate
-    result = runner.invoke(users_activate, ['-u', 'in@valid.org'],
+    result = runner.invoke(users_activate, ['in@valid.org'],
                            obj=script_info)
     assert result.exit_code != 0
-    result = runner.invoke(users_deactivate, ['-u', 'in@valid.org'],
+    result = runner.invoke(users_deactivate, ['in@valid.org'],
                            obj=script_info)
     assert result.exit_code != 0
 
-    result = runner.invoke(users_activate, ['-u', 'a@example.org'],
+    result = runner.invoke(users_activate, ['a@example.org'],
                            obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(users_activate, ['-u', 'a@example.org'],
+    result = runner.invoke(users_activate, ['a@example.org'],
                            obj=script_info)
     assert result.exit_code == 0
 
     # Deactivate
     result = runner.invoke(users_deactivate,
-                           ['-u', 'a@example.org'], obj=script_info)
+                           ['a@example.org'], obj=script_info)
     assert result.exit_code == 0
     result = runner.invoke(users_deactivate,
-                           ['-u', 'a@example.org'], obj=script_info)
+                           ['a@example.org'], obj=script_info)
     assert result.exit_code == 0


### PR DESCRIPTION
* Uses argument instead of option for required parameters. (closes #56)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>