### PR TITLE
tests: separate E2E test build matrix on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,16 @@ services:
   - postgresql
 
 env:
-  - REQUIREMENTS=lowest EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
-  - REQUIREMENTS=lowest EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio"
-  - REQUIREMENTS=lowest EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
-  - REQUIREMENTS=release EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
-  - REQUIREMENTS=release EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio"
-  - REQUIREMENTS=release EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
-  - REQUIREMENTS=devel EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
-  - REQUIREMENTS=devel EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio"
-  - REQUIREMENTS=devel EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
+  - REQUIREMENTS=devel E2E="yes" EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
+  - REQUIREMENTS=lowest E2E="no" EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
+  - REQUIREMENTS=lowest E2E="no" EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio"
+  - REQUIREMENTS=lowest E2E="no" EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
+  - REQUIREMENTS=release E2E="no" EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
+  - REQUIREMENTS=release E2E="no" EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio"
+  - REQUIREMENTS=release E2E="no" EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
+  - REQUIREMENTS=devel E2E="no" EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
+  - REQUIREMENTS=devel E2E="no" EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/invenio"
+  - REQUIREMENTS=devel E2E="no" EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
 
 python:
   - "2.7"
@@ -68,13 +69,11 @@ install:
   - "travis_retry pip install -e .[${EXTRAS}]"
 
 before_script:
-  - "export DISPLAY=:99.0" #set up xvfb, req'd for non-phantomJS webdrivers
-  - "sh -e /etc/init.d/xvfb start"
-  - "export E2E_WEBDRIVER_BROWSERS='Firefox'"
-  - "export E2E_WEBDRIVER_TIMEOUT='300'" # Max allowed time for E2E tests
+  - "if [ ${E2E} == 'yes' ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; export E2E_WEBDRIVER_BROWSERS='Firefox'; export E2E_WEBDRIVER_TIMEOUT='300'; fi"
+
 
 script:
-  - "./run-tests.sh"
+  - "if [ ${E2E} == 'yes' ]; then python setup.py test -a '-k \"e2e\"'; else ./run-tests.sh; fi"
 
 after_success:
   - coveralls

--- a/e2e_setup.sh
+++ b/e2e_setup.sh
@@ -22,10 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-
-pep257 invenio_accounts && \
-check-manifest --ignore ".travis-*" && \
-#isort -rc -c -df **/*.py && \
-sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test -a "-k 'not e2e'" && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+export DISPLAY=:99.0 #set up xvfb, req'd for non-phantomJS webdrivers
+sh -e /etc/init.d/xvfb start
+export E2E_WEBDRIVER_BROWSERS='Firefox'
+export E2E_WEBDRIVER_TIMEOUT='300' # Max allowed time in seconds for E2E tests


### PR DESCRIPTION
Not sure about the co-authored/signed-off-by attribution -- I've basically copied what Lars did in Zenodo.

This commit increases the Travis job count by 4 (one per Python version), meaning the total job count per build is now 40.
The E2E tests are excluded from 36 of the jobs (which now only run the unit tests), and run once in each of the four new jobs.
Does this reduce the overall build time?
- Old build time: `J * (tu + te) + JS`
- New build time: `S * (J + K) + J * tu + J * te)
- `J` is the number of jobs per build before this commit, `K` is the number of jobs added by this commit, `S` is the startup/setup time of a Travis job, `tu` is the avg. run time of the unit tests, `te` is the avg. run time of the E2E tests.
- If `J * te > K * (S + te)` (it takes less time to set up `K` travis jobs and run the E2E tests `K` times than it does to run the E2E tests `J` times), this commit reduces the total build time.