### PR TITLE
global: i18n fixes

### DIFF
--- a/invenio_accounts/templates/invenio_accounts/forgot_password.html
+++ b/invenio_accounts/templates/invenio_accounts/forgot_password.html
@@ -50,7 +50,7 @@
     {# contents of this if-block can be always shown after mattupstate/flask-security#291 is released. #}
     {%- if current_user.is_anonymous %}
     <div class="panel-footer text-center">
-        <h4 class="text-muted"><a href="{{url_for('security.login')}}">{{_('Log In')}}</a>{% if security.registerable %} or <a href="{{url_for('security.register')}}">{{_('Sign Up')}}</a>{% endif %}</h4>
+        <h4 class="text-muted"><a href="{{url_for('security.login')}}">{{_('Log In')}}</a>{% if security.registerable %} {{_('or')}} <a href="{{url_for('security.register')}}">{{_('Sign Up')}}</a>{% endif %}</h4>
     </div>
     {%- endif %}
   </div>

--- a/invenio_accounts/templates/invenio_accounts/reset_password.html
+++ b/invenio_accounts/templates/invenio_accounts/reset_password.html
@@ -22,10 +22,39 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
+
 {%- extends config.ACCOUNTS_COVER_TEMPLATE %}
 
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "invenio_accounts/_macros.html" import render_field, form_errors %}
+{%- set messages = get_flashed_messages(with_categories=true) -%}
 
 {% block panel %}
-{% include "security/reset_password.html" %}
+{%- with form = reset_password_form %}
+<div class="col-md-6 col-md-offset-3">
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <h3 class="text-center panel-free-title">{{_('Reset Password')}}</h3>
+      {%- if messages %}
+      {%- for category, message in messages %}
+        <p>{{ message }}</p>
+      {%- endfor %}
+      {%- else %}
+      <form action="{{ url_for_security('reset_password', token=reset_password_token) }}" method="POST" name="reset_password_form">
+        {{ form.hidden_tag() }}
+        {{ render_field(reset_password_form.password, icon="glyphicon glyphicon-user", autofocus=True) }}
+        {{ render_field(reset_password_form.password_confirm, icon="glyphicon glyphicon-user", autofocus=True) }}
+        <button type="submit" class="btn btn-primary btn-lg btn-block">{{_('Reset Password')}}</button>
+      </form>
+      {%- endif %}
+    </div>
+
+    {# contents of this if-block can be always shown after mattupstate/flask-security#291 is released. #}
+    {%- if current_user.is_anonymous %}
+    <div class="panel-footer text-center">
+        <h4 class="text-muted"><a href="{{url_for('security.login')}}">{{_('Log In')}}</a>{% if security.registerable %} {{_('or')}} <a href="{{url_for('security.register')}}">{{_('Sign Up')}}</a>{% endif %}</h4>
+    </div>
+    {%- endif %}
+  </div>
+</div>
+{%- endwith %}
 {% endblock panel %}

--- a/invenio_accounts/views.py
+++ b/invenio_accounts/views.py
@@ -27,7 +27,7 @@
 from __future__ import absolute_import, print_function
 
 from flask import Blueprint, current_app
-from flask_babelex import gettext as _
+from flask_babelex import lazy_gettext as _
 from flask_menu import current_menu
 
 blueprint = Blueprint(
@@ -67,4 +67,6 @@ def init_menu():
     item.register(
         "{0}.change_password".format(
             current_app.config['SECURITY_BLUEPRINT_NAME']),
-        _('%(icon)s Change Password', icon='<i class="fa fa-key fa-fw"></i>'))
+        # NOTE: Menu item text (icon replaced by a user icon).
+        _('%(icon)s Change Password', icon='<i class="fa fa-key fa-fw"></i>'),
+        order=1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ copyright_holder = CERN
 msgid_bugs_address = info@invenio-software.org
 mapping-file = babel.ini
 output-file = invenio_accounts/translations/messages.pot
+add-comments = NOTE
 
 [init_catalog]
 input-file = invenio_accounts/translations/messages.pot


### PR DESCRIPTION
* Fixes missing string translation in templates.

* Adds lazy translation of settings menu item.

* Adds extraction of translation notes.

* Adds reset password template.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>