### PR TITLE
tests: addition of in-memory KVSession cache

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -76,6 +76,7 @@ Invenio user management and authentication.
 - Peter Halliday <phalliday@cornell.edu>
 - Piotr Praczyk <piotr.praczyk@gmail.com>
 - Raquel Jimenez Encinar <raquel.jimenez.encinar@cern.ch>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Samuele Carli <samuele.carli@cern.ch>
 - Samuele Kaplun <samuele.kaplun@cern.ch>
 - Thomas Baron <thomas.baron@cern.ch>

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -26,6 +26,8 @@
 
 from __future__ import absolute_import, print_function
 
+import os
+
 import pkg_resources
 from flask_kvsession import KVSessionExtension
 from flask_login import user_logged_in
@@ -62,11 +64,17 @@ class InvenioAccounts(object):
 
         # Create sessionstore
         if sessionstore is None:
-            import redis
-            from simplekv.memory.redisstore import RedisStore
+            if app.testing and \
+                    os.environ.get('CI', 'false') == 'false':
+                from simplekv.memory import DictStore
 
-            sessionstore = RedisStore(redis.StrictRedis.from_url(
-                app.config['ACCOUNTS_SESSION_REDIS_URL']))
+                sessionstore = DictStore()
+            else:
+                import redis
+                from simplekv.memory.redisstore import RedisStore
+
+                sessionstore = RedisStore(redis.StrictRedis.from_url(
+                    app.config['ACCOUNTS_SESSION_REDIS_URL']))
 
         user_logged_in.connect(login_listener, app)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -31,6 +31,7 @@ import time
 import flask
 import flask_kvsession
 import flask_security
+import pytest
 import redis
 from flask_login import user_logged_in, user_logged_out
 from invenio_db import db
@@ -132,10 +133,13 @@ def test_sessionstore_default_ttl_secs(app):
 
     See http://pythonhosted.org/simplekv/index.html#simplekv.TimeToLiveMixin.
     """
+    if type(app.kvsession_store) is not RedisStore:
+        pytest.skip('TTL support needed, this test requires Redis.')
+
     ttl_seconds = 1
     ttl_delta = datetime.timedelta(0, ttl_seconds)
 
-    sessionstore = RedisStore(redis.StrictRedis())
+    sessionstore = app.kvsession_store
     sessionstore.default_ttl_secs = ttl_seconds
 
     # Verify that the backend supports ttl
@@ -161,6 +165,9 @@ def test_sessionstore_default_ttl_secs(app):
 
 def test_session_ttl(app):
     """Test actual/working session expiration/TTL settings."""
+    if type(app.kvsession_store) is not RedisStore:
+        pytest.skip('TTL support needed, this test requires Redis.')
+
     ttl_seconds = 1
     # Set ttl to "0 days, 1 seconds"
     ttl_delta = datetime.timedelta(0, ttl_seconds)


### PR DESCRIPTION
* Adds an in-memory KVSession DictStore cache. Running tests locally
  no longer requires Redis. Travis will still run with Redis.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>