### PR TITLE
global: transactions for session activity and coverage

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -68,12 +68,11 @@ class InvenioAccounts(object):
             sessionstore = RedisStore(redis.StrictRedis.from_url(
                 app.config['ACCOUNTS_SESSION_REDIS_URL']))
 
-        self.sessionstore = sessionstore
         user_logged_in.connect(login_listener, app)
 
         # Initialize extension.
         state = self.security.init_app(app, datastore=self.datastore)
-        self.kvsession_extension = KVSessionExtension(self.sessionstore, app)
+        self.kvsession_extension = KVSessionExtension(sessionstore, app)
 
         if app.config['ACCOUNTS_USE_CELERY']:
             from invenio_accounts.tasks import send_security_email
@@ -94,7 +93,7 @@ class InvenioAccounts(object):
             pkg_resources.get_distribution('celery')
             app.config.setdefault(
                 "ACCOUNTS_USE_CELERY", not (app.debug or app.testing))
-        except pkg_resources.DistributionNotFound:
+        except pkg_resources.DistributionNotFound:  # pragma: no cover
             app.config.setdefault("ACCOUNTS_USE_CELERY", False)
 
         app.config.setdefault('ACCOUNTS', True)

--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -101,15 +101,13 @@ class SessionActivity(db.Model, Timestamp):
 
     __tablename__ = "accounts_user_session_activity"
 
-    id = db.Column(db.Integer, primary_key=True)
-
-    user_id = db.Column(db.Integer, db.ForeignKey(User.id))
-    """ID of user to whom this session belongs."""
-
-    sid_s = db.Column(db.String(255), unique=True, index=True)
+    sid_s = db.Column(db.String(255), primary_key=True)
     """Serialized Session ID. Used as the session's key in the kv-session
     store employed by `flask-kvsession`.
     Named here as it is in `flask-kvsession` to avoid confusion.
     """
+
+    user_id = db.Column(db.Integer, db.ForeignKey(User.id))
+    """ID of user to whom this session belongs."""
 
     user = db.relationship(User, backref='active_sessions')

--- a/invenio_accounts/sessions.py
+++ b/invenio_accounts/sessions.py
@@ -40,8 +40,7 @@ from werkzeug.local import LocalProxy
 
 from invenio_accounts.models import SessionActivity
 
-_sessionstore = LocalProxy(lambda: flask.current_app.
-                           extensions['invenio-accounts'].sessionstore)
+_sessionstore = LocalProxy(lambda: flask.current_app.kvsession_store)
 
 
 def add_session(session=None):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -62,13 +62,13 @@ def app(request):
         CELERY_CACHE_BACKEND="memory",
         CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
         CELERY_RESULT_BACKEND="cache",
+        LOGIN_DISABLED=False,
         MAIL_SUPPRESS_SEND=True,
         SECRET_KEY="CHANGE_ME",
         SECURITY_PASSWORD_SALT="CHANGE_ME_ALSO",
         SQLALCHEMY_DATABASE_URI=os.environ.get(
             'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'),
         TESTING=True,
-        LOGIN_DISABLED=False,
     )
     FlaskCLI(app)
     Menu(app)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -41,8 +41,6 @@ _datastore = LocalProxy(
 
 def test_admin(app):
     """Test flask-admin interace."""
-    InvenioAccounts(app)
-
     assert isinstance(role_adminview, dict)
     assert isinstance(user_adminview, dict)
 
@@ -66,30 +64,31 @@ def test_admin(app):
                       password=encrypt_password('aafaf4as5fa'))
         _datastore.create_user(**kwargs)
         _datastore.commit()
+        inserted_id = _datastore.get_user('test@test.cern').id
 
-    with app.app_context():
-        with app.test_client() as client:
-            inserted_id = _datastore.get_user('test@test.cern').id
+    with app.test_client() as client:
 
-            res = client.post(
-                request_url,
-                data={'rowid': inserted_id, 'action': 'activate'},
-                follow_redirects=True
-            )
-            assert res.status_code == 200
+        res = client.post(
+            request_url,
+            data={'rowid': inserted_id, 'action': 'activate'},
+            follow_redirects=True
+        )
+        assert res.status_code == 200
 
-            res = client.post(
-                request_url,
-                data={'rowid': inserted_id, 'action': 'inactivate'},
-                follow_redirects=True
-            )
-            assert res.status_code == 200
+        res = client.post(
+            request_url,
+            data={'rowid': inserted_id, 'action': 'inactivate'},
+            follow_redirects=True
+        )
+        assert res.status_code == 200
 
-            pytest.raises(ValueError, client.post, request_url,
-                          data={'rowid': -42, 'action': 'inactivate'},
-                          follow_redirects=True
-                          )
-            pytest.raises(ValueError, client.post, request_url,
-                          data={'rowid': -42, 'action': 'activate'},
-                          follow_redirects=True
-                          )
+        pytest.raises(
+            ValueError, client.post, request_url,
+            data={'rowid': -42, 'action': 'inactivate'},
+            follow_redirects=True
+        )
+        pytest.raises(
+            ValueError, client.post, request_url,
+            data={'rowid': -42, 'action': 'activate'},
+            follow_redirects=True
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -41,6 +41,14 @@ def test_cli_createuser(script_info):
     result = runner.invoke(
         users_create, input='1234\n1234\n', obj=script_info)
     assert result.exit_code != 0
+
+    # Create user with invalid email
+    result = runner.invoke(
+        users_create,
+        ['not-an-email', '--password', '123456'],
+        obj=script_info
+    )
+    assert result.exit_code == 2
 
     # Create user
     result = runner.invoke(

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -35,7 +35,6 @@ from invenio_db import InvenioDB
 
 from invenio_accounts import InvenioAccounts
 from invenio_accounts.models import Role, User
-from invenio_accounts.views import blueprint
 
 
 def test_version():
@@ -67,8 +66,7 @@ def test_init():
 
 def test_datastore_usercreate(app):
     """Test create user."""
-    ext = InvenioAccounts(app)
-    ds = ext.datastore
+    ds = app.extensions['invenio-accounts'].datastore
 
     with app.app_context():
         u1 = ds.create_user(email='info@invenio-software.org', password='1234',
@@ -82,8 +80,7 @@ def test_datastore_usercreate(app):
 
 def test_datastore_rolecreate(app):
     """Test create user."""
-    ext = InvenioAccounts(app)
-    ds = ext.datastore
+    ds = app.extensions['invenio-accounts'].datastore
 
     with app.app_context():
         r1 = ds.create_role(name='superuser', description='1234')
@@ -96,8 +93,7 @@ def test_datastore_rolecreate(app):
 
 def test_datastore_assignrole(app):
     """Create and assign user to role."""
-    ext = InvenioAccounts(app)
-    ds = ext.datastore
+    ds = app.extensions['invenio-accounts'].datastore
 
     with app.app_context():
         u = ds.create_user(email='info@invenio-software.org', password='1234',
@@ -112,9 +108,6 @@ def test_datastore_assignrole(app):
 
 def test_view(app):
     """Test view."""
-    InvenioAccounts(app)
-    app.register_blueprint(blueprint)
-
     with app.app_context():
         login_url = url_for_security('login')
 
@@ -123,8 +116,9 @@ def test_view(app):
         assert res.status_code == 200
 
 
-def test_configuration(app):
+def test_configuration(base_app):
     """Test configuration."""
+    app = base_app
     app.config['ACCOUNTS_USE_CELERY'] = 'deadbeef'
     InvenioAccounts(app)
     assert 'deadbeef' == app.config['ACCOUNTS_USE_CELERY']

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import
 
+from invenio_db import db
 from sqlalchemy import inspect
 
 from invenio_accounts import InvenioAccounts, testutils
@@ -38,53 +39,51 @@ def test_session_activity_model(app):
     ext = InvenioAccounts(app)
     app.register_blueprint(blueprint)
 
-    # SessionActivity table is in the datastore database.
-    datastore = app.extensions['invenio-accounts'].datastore
-    inspector = inspect(datastore.db.engine)
-    assert 'accounts_user_session_activity' in inspector.get_table_names()
+    with app.app_context():
+        # SessionActivity table is in the database
+        inspector = inspect(db.engine)
+        assert 'accounts_user_session_activity' in inspector.get_table_names()
 
-    user = testutils.create_test_user()
+        user = testutils.create_test_user()
 
-    # Create a new SessionActivity object, put it in the datastore.
-    session_activity = SessionActivity(user_id=user.get_id(),
-                                       sid_s="teststring")
-    database = datastore.db
+        # Create a new SessionActivity object, put it in the db
+        session_activity = SessionActivity(user_id=user.get_id(),
+                                           sid_s="teststring")
+        database = db
 
-    # the `created` field is magicked in via the Timestamp mixin class
-    assert not session_activity.created
-    assert not session_activity.id
-    database.session.add(session_activity)
-    # Commit it to the books.
-    database.session.commit()
-    assert session_activity.created
-    assert session_activity.id
-    assert len(user.active_sessions) == 1
+        # the `created` field is magicked in via the Timestamp mixin class
+        assert not session_activity.created
+        database.session.add(session_activity)
+        # Commit it to the books.
+        database.session.commit()
+        assert session_activity.created
+        assert len(user.active_sessions) == 1
 
-    # Now how does this look on the user object?
-    assert session_activity == user.active_sessions[0]
+        # Now how does this look on the user object?
+        assert session_activity == user.active_sessions[0]
 
-    session_two = SessionActivity(user_id=user.get_id(),
-                                  sid_s="testring_2")
-    database.session.add(session_two)
-    # Commit it to the books.
-    database.session.commit()
+        session_two = SessionActivity(user_id=user.get_id(),
+                                      sid_s="testring_2")
+        database.session.add(session_two)
+        # Commit it to the books.
+        database.session.commit()
 
-    assert len(user.active_sessions) == 2
-    # Check #columns in table
-    queried = database.session.query(SessionActivity)
-    assert queried.count() == 2
-    active_sessions = queried.all()
-    assert session_activity.sid_s in [x.sid_s for x in active_sessions]
-    assert session_two in queried.filter(
-        SessionActivity.sid_s == session_two.sid_s)
-    assert queried.count() == 2  # `.filter` doesn't change the query
+        assert len(user.active_sessions) == 2
+        # Check #columns in table
+        queried = database.session.query(SessionActivity)
+        assert queried.count() == 2
+        active_sessions = queried.all()
+        assert session_activity.sid_s in [x.sid_s for x in active_sessions]
+        assert session_two in queried.filter(
+            SessionActivity.sid_s == session_two.sid_s)
+        assert queried.count() == 2  # `.filter` doesn't change the query
 
-    # Test session deletion
-    session_to_delete = user.active_sessions[0]
-    database.session.delete(session_to_delete)
-    assert len(user.active_sessions) == 2  # Not yet updated.
-    assert queried.count() == 1
-    # Deletion is visible on `user` once database session is commited.
-    database.session.commit()
-    assert len(user.active_sessions) == 1
-    assert user.active_sessions[0].sid_s != session_to_delete.sid_s
+        # Test session deletion
+        session_to_delete = user.active_sessions[0]
+        database.session.delete(session_to_delete)
+        assert len(user.active_sessions) == 2  # Not yet updated.
+        assert queried.count() == 1
+        # Deletion is visible on `user` once database session is commited.
+        database.session.commit()
+        assert len(user.active_sessions) == 1
+        assert user.active_sessions[0].sid_s != session_to_delete.sid_s

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,9 +36,6 @@ from invenio_accounts.views import blueprint
 
 def test_session_activity_model(app):
     """Test SessionActivity model."""
-    ext = InvenioAccounts(app)
-    app.register_blueprint(blueprint)
-
     with app.app_context():
         # SessionActivity table is in the database
         inspector = inspect(db.engine)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -33,6 +33,7 @@ import flask_kvsession
 import flask_security
 import redis
 from flask_login import user_logged_in, user_logged_out
+from invenio_db import db
 from itsdangerous import Signer
 from simplekv.memory.redisstore import RedisStore
 from werkzeug.local import LocalProxy
@@ -42,9 +43,6 @@ from invenio_accounts.models import SessionActivity
 from invenio_accounts.sessions import delete_session, login_listener
 from invenio_accounts.views import blueprint
 
-_datastore = LocalProxy(lambda: flask.current_app.
-                        extensions['invenio-accounts'].datastore)
-
 _sessionstore = LocalProxy(lambda: flask.current_app.
                            extensions['invenio-accounts'].sessionstore)
 
@@ -53,24 +51,24 @@ def test_login_listener(app):
     """Test sessions.py:login_listener"""
     InvenioAccounts(app)
     app.register_blueprint(blueprint)
+    with app.app_context():
+        with app.test_client() as client:
+            user = testutils.create_test_user()
+            # The SessionActivity table is initially empty
+            query = db.session.query(SessionActivity)
+            assert query.count() == 0
 
-    user = testutils.create_test_user()
-    # The SessionActivity table is initially empty
-    query = _datastore.db.session.query(SessionActivity)
-    assert query.count() == 0
+            testutils.login_user_via_view(client, user.email,
+                                          user.password_plaintext)
+            assert testutils.client_authenticated(client)
+            # After logging in, a SessionActivity has been created
+            # corresponding to the user's session.
+            query = db.session.query(SessionActivity)
+            assert query.count() == 1
 
-    with app.test_client() as client:
-        testutils.login_user_via_view(client, user.email,
-                                      user.password_plaintext)
-        assert testutils.client_authenticated(client)
-        # After logging in, a SessionActivity has been created corresponding
-        # to the user's session.
-        query = _datastore.db.session.query(SessionActivity)
-        assert query.count() == 1
-
-        session_entry = query.first()
-        assert session_entry.user_id == user.id
-        assert session_entry.sid_s == flask.session.sid_s
+            session_entry = query.first()
+            assert session_entry.user_id == user.id
+            assert session_entry.sid_s == flask.session.sid_s
 
 
 def test_repeated_login_session_population(app):
@@ -79,30 +77,31 @@ def test_repeated_login_session_population(app):
     InvenioAccounts(app)
     app.register_blueprint(blueprint)
 
-    user = testutils.create_test_user()
-    query = _datastore.db.session.query(SessionActivity)
-    assert query.count() == len(testutils.get_kvsession_keys())
-
-    with app.test_client() as client:
-        # After logging in, there should be one session in the kv-store and
-        # one SessionActivity
-        testutils.login_user_via_view(client, user=user)
-        assert testutils.client_authenticated(client)
-        query = _datastore.db.session.query(SessionActivity)
-        assert query.count() == 1
+    with app.app_context():
+        user = testutils.create_test_user()
+        query = db.session.query(SessionActivity)
         assert query.count() == len(testutils.get_kvsession_keys())
 
-        # Sessions are not deleted upon logout
-        client.get(flask_security.url_for_security('logout'))
-        assert len(testutils.get_kvsession_keys()) == 1
-        query = _datastore.db.session.query(SessionActivity)
-        assert query.count() == len(testutils.get_kvsession_keys())
+        with app.test_client() as client:
+            # After logging in, there should be one session in the kv-store and
+            # one SessionActivity
+            testutils.login_user_via_view(client, user=user)
+            assert testutils.client_authenticated(client)
+            query = db.session.query(SessionActivity)
+            assert query.count() == 1
+            assert query.count() == len(testutils.get_kvsession_keys())
 
-        # After logging out and back in, the number of sessions correspond to
-        # the number of SessionActivity entries.
-        testutils.login_user_via_view(client, user=user)
-        query = _datastore.db.session.query(SessionActivity)
-        assert query.count() == len(testutils.get_kvsession_keys())
+            # Sessions are not deleted upon logout
+            client.get(flask_security.url_for_security('logout'))
+            assert len(testutils.get_kvsession_keys()) == 1
+            query = db.session.query(SessionActivity)
+            assert query.count() == len(testutils.get_kvsession_keys())
+
+            # After logging out and back in, the number of sessions correspond
+            # to the number of SessionActivity entries.
+            testutils.login_user_via_view(client, user=user)
+            query = db.session.query(SessionActivity)
+            assert query.count() == len(testutils.get_kvsession_keys())
 
 
 def test_login_multiple_clients_single_user_session_population(app):
@@ -111,23 +110,26 @@ def test_login_multiple_clients_single_user_session_population(app):
     InvenioAccounts(app)
     app.register_blueprint(blueprint)
 
-    user = testutils.create_test_user()
-    client_count = 3
-    clients = [app.test_client() for _ in range(client_count)]
-    sid_s_list = []
-    for c in clients:
-        with c as client:
-            testutils.login_user_via_view(client, user=user)
-            assert testutils.client_authenticated(client)
-            sid_s_list.append(flask.session.sid_s)
-            response = client.get(flask_security.url_for_security('logout'))
-            assert not testutils.client_authenticated(client)
-    # There is now `client_count` existing sessions and SessionActivity
-    # entries
-    assert len(testutils.get_kvsession_keys()) == client_count
-    query = _datastore.db.session.query(SessionActivity)
-    assert query.count() == client_count
-    assert len(user.active_sessions) == client_count
+    with app.app_context():
+        user = testutils.create_test_user()
+
+        client_count = 3
+        clients = [app.test_client() for _ in range(client_count)]
+        sid_s_list = []
+        for c in clients:
+            with c as client:
+                testutils.login_user_via_view(client, user=user)
+                assert testutils.client_authenticated(client)
+                sid_s_list.append(flask.session.sid_s)
+                response = client.get(
+                    flask_security.url_for_security('logout'))
+                assert not testutils.client_authenticated(client)
+        # There is now `client_count` existing sessions and SessionActivity
+        # entries
+        assert len(testutils.get_kvsession_keys()) == client_count
+        query = db.session.query(SessionActivity)
+        assert query.count() == client_count
+        assert len(user.active_sessions) == client_count
 
 
 def test_sessionstore_default_ttl_secs(app):
@@ -146,18 +148,20 @@ def test_sessionstore_default_ttl_secs(app):
     # Verify that the backend supports ttl
     assert ext.sessionstore.ttl_support
 
-    user = testutils.create_test_user()
-    with app.test_client() as client:
-        testutils.login_user_via_view(client, user=user)
-        sid = testutils.unserialize_session(flask.session.sid_s)
-        while not sid.has_expired(ttl_delta):
-            pass
-        # When we get here the session should have expired.
-        # But the client is still authenticated.
-        assert testutils.client_authenticated(client)
-        # Why? Because `flask_kvsession` doesn't care about the sessionstore's
-        # `default_ttl_seconds`. It uses the `PERMANENT_SESSION_LIFETIME`
-        # from the app's config.
+    with app.app_context():
+        user = testutils.create_test_user()
+
+        with app.test_client() as client:
+            testutils.login_user_via_view(client, user=user)
+            sid = testutils.unserialize_session(flask.session.sid_s)
+            while not sid.has_expired(ttl_delta):
+                pass
+            # When we get here the session should have expired.
+            # But the client is still authenticated.
+            assert testutils.client_authenticated(client)
+            # Why? Because `flask_kvsession` doesn't care about
+            # the sessionstore's `default_ttl_seconds`. It uses
+            # the `PERMANENT_SESSION_LIFETIME` from the app's config.
 
 
 def test_session_ttl(app):
@@ -176,22 +180,24 @@ def test_session_ttl(app):
     app.config['PERMANENT_SESSION_LIFETIME'] = ttl_delta
     assert app.permanent_session_lifetime.total_seconds() == ttl_seconds
 
-    user = testutils.create_test_user()
-    with app.test_client() as client:
-        testutils.login_user_via_view(client, user=user)
-        assert len(testutils.get_kvsession_keys()) == 1
+    with app.app_context():
+        user = testutils.create_test_user()
 
-        sid = testutils.unserialize_session(flask.session.sid_s)
-        testutils.let_session_expire()
+        with app.test_client() as client:
+            testutils.login_user_via_view(client, user=user)
+            assert len(testutils.get_kvsession_keys()) == 1
 
-        assert sid.has_expired(ttl_delta)
-        assert not testutils.client_authenticated(client)
+            sid = testutils.unserialize_session(flask.session.sid_s)
+            testutils.let_session_expire()
 
-        # Expired sessions are automagically removed from the sessionstore
-        # Although not _instantly_.
-        while len(testutils.get_kvsession_keys()) > 0:
-            pass
-        assert len(testutils.get_kvsession_keys()) == 0
+            assert sid.has_expired(ttl_delta)
+            assert not testutils.client_authenticated(client)
+
+            # Expired sessions are automagically removed from the sessionstore
+            # Although not _instantly_.
+            while len(testutils.get_kvsession_keys()) > 0:
+                pass
+            assert len(testutils.get_kvsession_keys()) == 0
 
 
 def test_repeated_login_session_expiration(app):
@@ -203,18 +209,20 @@ def test_repeated_login_session_expiration(app):
     ttl_delta = datetime.timedelta(0, ttl_seconds)
     app.config['PERMANENT_SESSION_LIFETIME'] = ttl_delta
 
-    user = testutils.create_test_user()
-    with app.test_client() as client:
-        testutils.login_user_via_view(client, user=user)
-        first_sid_s = flask.session.sid_s
-        testutils.let_session_expire()
-        assert not testutils.client_authenticated(client)
+    with app.app_context():
+        user = testutils.create_test_user()
+        with app.test_client() as client:
+            testutils.login_user_via_view(client, user=user)
+            first_sid_s = flask.session.sid_s
+            testutils.let_session_expire()
+            assert not testutils.client_authenticated(client)
 
-        app.config['PERMANENT_SESSION_LIFETIME'] = datetime.timedelta(0, 10000)
-        testutils.login_user_via_view(client, user=user)
-        second_sid_s = flask.session.sid_s
+            app.config['PERMANENT_SESSION_LIFETIME'] = datetime.timedelta(
+                0, 10000)
+            testutils.login_user_via_view(client, user=user)
+            second_sid_s = flask.session.sid_s
 
-        assert not first_sid_s == second_sid_s
+            assert not first_sid_s == second_sid_s
 
 
 def test_session_deletion(app):
@@ -222,26 +230,29 @@ def test_session_deletion(app):
     deleted via `delete_session`."""
     InvenioAccounts(app)
     app.register_blueprint(blueprint)
-    user = testutils.create_test_user()
 
-    with app.test_client() as client:
-        testutils.login_user_via_view(client, user=user)
-        assert testutils.client_authenticated(client)
-        assert len(user.active_sessions) == 1
-        saved_sid_s = flask.session.sid_s
+    with app.app_context():
+        user = testutils.create_test_user()
 
-        delete_session(saved_sid_s)
-        # The user now has no active sessions
-        assert len(testutils.get_kvsession_keys()) == 0
-        assert len(user.active_sessions) == 0
-        query = _datastore.db.session.query(SessionActivity)
-        assert query.count() == 0
+        with app.test_client() as client:
+            testutils.login_user_via_view(client, user=user)
+            assert testutils.client_authenticated(client)
+            assert len(user.active_sessions) == 1
+            saved_sid_s = flask.session.sid_s
 
-        # After deleting the session, the client is not authenticated
-        assert not testutils.client_authenticated(client)
+            delete_session(saved_sid_s)
+            db.session.commit()
+            # The user now has no active sessions
+            assert len(testutils.get_kvsession_keys()) == 0
+            assert len(user.active_sessions) == 0
+            query = db.session.query(SessionActivity)
+            assert query.count() == 0
 
-        # A new session is created in the kv-sessionstore, but its
-        # sid_s is different and the user is not authenticated with it.
-        assert len(testutils.get_kvsession_keys()) == 1
-        assert not flask.session.sid_s == saved_sid_s
-        assert not testutils.client_authenticated(client)
+            # After deleting the session, the client is not authenticated
+            assert not testutils.client_authenticated(client)
+
+            # A new session is created in the kv-sessionstore, but its
+            # sid_s is different and the user is not authenticated with it.
+            assert len(testutils.get_kvsession_keys()) == 1
+            assert not flask.session.sid_s == saved_sid_s
+            assert not testutils.client_authenticated(client)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -37,8 +37,6 @@ def test_no_log_in_message_for_logged_in_users(app):
     Password reset form should not show log in or sign up messages for logged
     in users.
     """
-    InvenioAccounts(app)
-    app.register_blueprint(blueprint)
     with app.app_context():
         forgot_password_url = url_for_security('forgot_password')
 


### PR DESCRIPTION
- Refactors tests and improves test coverage.
- Removes `id` column from SessionActivity as `sid_s` should be __the__ primary key.

--
closes #108