### PR TITLE
global: support for legacy invenio password hashes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -71,6 +71,7 @@ Invenio user management and authentication.
 - Mikael Karlsson <i8myshoes@gmail.com>
 - Nicholas Robinson <nicholas.robinson@cern.ch>
 - Nikolaos Kasioumis <nikolaos.kasioumis@cern.ch>
+- Orestis Melkonian <melkon.or@gmail.com>
 - Patrick Glauner <patrick.oliver.glauner@cern.ch>
 - Paulo Cabral <paulo.cabral@cern.ch>
 - Peter Halliday <phalliday@cornell.edu>

--- a/invenio_accounts/hash.py
+++ b/invenio_accounts/hash.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Legacy Invenio hash support."""
+
+import hashlib
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from passlib.utils.compat import str_to_uascii
+from passlib.utils.handlers import GenericHandler, HasSalt, parse_mc2, \
+    render_mc2
+from six import PY3, binary_type, text_type
+
+__all__ = ('invenio_aes_encrypted_email', )
+
+
+def _to_binary(val):
+    """Convert to binary."""
+    if isinstance(val, text_type):
+        return val.encode('utf-8')
+    assert isinstance(val, binary_type)
+    return val
+
+
+def _to_string(val):
+    """Convert to text."""
+    if isinstance(val, binary_type):
+        return val.decode('utf-8')
+    assert isinstance(val, text_type)
+    return val
+
+
+def _mysql_aes_key(key):
+    """Format key."""
+    final_key = bytearray(16)
+    for i, c in enumerate(key):
+        final_key[i % 16] ^= key[i] if PY3 else ord(key[i])
+    return bytes(final_key)
+
+
+def _mysql_aes_pad(val):
+    """Padding."""
+    val = _to_string(val)
+    pad_value = 16 - (len(val) % 16)
+    return _to_binary('{0}{1}'.format(val, chr(pad_value) * pad_value))
+
+
+def _mysql_aes_unpad(val):
+    """Reverse padding."""
+    val = _to_string(val)
+    pad_value = ord(val[-1])
+    return val[:-pad_value]
+
+
+def _mysql_aes_engine(key):
+    """Create MYSQL AES cipher engine."""
+    return Cipher(algorithms.AES(key), modes.ECB(), default_backend())
+
+
+def mysql_aes_encrypt(val, key):
+    """Mysql AES encrypt value with secret key."""
+    assert isinstance(val, binary_type) or isinstance(val, text_type)
+    assert isinstance(key, binary_type) or isinstance(key, text_type)
+    k = _mysql_aes_key(_to_binary(key))
+    v = _mysql_aes_pad(_to_binary(val))
+    e = _mysql_aes_engine(k).encryptor()
+
+    return e.update(v) + e.finalize()
+
+
+def mysql_aes_decrypt(encrypted_val, key):
+    """Mysql AES decrypt value with secret key."""
+    assert isinstance(encrypted_val, binary_type) \
+        or isinstance(encrypted_val, text_type)
+    assert isinstance(key, binary_type) or isinstance(key, text_type)
+    k = _mysql_aes_key(_to_binary(key))
+    d = _mysql_aes_engine(_to_binary(k)).decryptor()
+    return _mysql_aes_unpad(d.update(_to_binary(encrypted_val)) + d.finalize())
+
+
+class InvenioAesEncryptedEmail(HasSalt, GenericHandler):
+    """Invenio AES encryption of user email using password as secret key.
+
+    Invenio 1.x was AES encrypting the users email address with the password
+    as the secret key and storing it in a blob column. This e.g. caused
+    problems when a user wanted to change email address.
+    This hashing engine, differs from Invenio 1.x in that it sha256 hashes the
+    encrypted value as well to produce a string in the same length instead of
+    a binary blob. It is not done for extra security, just for convenience of
+    migration to using passlib's sha512.
+    An upgrade recipe is provided to migrated existing binary password hashes
+    to hashes of this engine.
+    """
+
+    name = "invenio_aes_encrypted_email"
+    setting_kwds = "salt"
+    ident = u"$invenio-aes$"
+
+    @classmethod
+    def from_string(cls, hash, **context):
+        """Parse instance from configuration string in Modular Crypt Format."""
+        salt, checksum = parse_mc2(hash, cls.ident, handler=cls)
+
+        return cls(salt=salt, checksum=checksum)
+
+    def to_string(self):
+        """Render instance to configuration string in Modular Crypt Format."""
+        return render_mc2(self.ident, self.salt, self.checksum)
+
+    def _calc_checksum(self, secret):
+        """Calculate string."""
+        return str_to_uascii(
+            hashlib.sha256(mysql_aes_encrypt(self.salt, secret)).hexdigest()
+        )

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'cryptography>=1.3',
     'Flask-BabelEx>=0.9.2',
     'Flask-Login>=0.3.0',
     'Flask-Menu>=0.4.0',

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test password hashing."""
+
+from __future__ import absolute_import, print_function
+
+from binascii import hexlify, unhexlify
+
+import flask
+import pytest
+from flask_security.utils import encrypt_password, verify_password
+
+from invenio_accounts.hash import _to_binary, _to_string, mysql_aes_decrypt, \
+    mysql_aes_encrypt
+from invenio_accounts.testutils import client_authenticated, \
+    create_test_user, login_user_via_view
+
+
+def test_mysql_aes_encrypt():
+    """Test mysql_aes_encrypt."""
+    assert hexlify(mysql_aes_encrypt("test", "key")) == \
+        b'9e9ce44cd9df2b201f51947e03bccbe2'
+    assert hexlify(mysql_aes_encrypt(u"test", "key")) == \
+        b'9e9ce44cd9df2b201f51947e03bccbe2'
+    assert hexlify(mysql_aes_encrypt("test", u"key")) == \
+        b'9e9ce44cd9df2b201f51947e03bccbe2'
+    assert hexlify(mysql_aes_encrypt(u"test", u"key")) == \
+        b'9e9ce44cd9df2b201f51947e03bccbe2'
+    pytest.raises(AssertionError, mysql_aes_encrypt, object(), "key")
+    pytest.raises(AssertionError, mysql_aes_encrypt, "val", object())
+
+
+def test_mysql_aes_decrypt():
+    """Test mysql_aes_encrypt."""
+    assert mysql_aes_decrypt(
+        unhexlify(b'9e9ce44cd9df2b201f51947e03bccbe2'), "key") == "test"
+    assert mysql_aes_decrypt(
+        unhexlify(u"9e9ce44cd9df2b201f51947e03bccbe2"), u"key") == "test"
+    pytest.raises(AssertionError, mysql_aes_decrypt, object(), "key")
+    pytest.raises(AssertionError, mysql_aes_decrypt, "val", object())
+
+
+def test_context(app):
+    """Test passlib password context."""
+    with app.app_context():
+        ctx = flask.current_app.extensions['security'].pwd_context
+        hashval = encrypt_password("test")
+        assert hashval != "test"
+        assert verify_password("test", hashval)
+        assert not ctx.needs_update(hashval)
+        assert ctx.encrypt("test") != ctx.encrypt("test")
+
+
+def test_conversion():
+    """Test conversion between bytes and text."""
+    str = 'abcd1234'
+    byte_str = b'abcd1234'
+    u_str = u'abcd1234'
+    assert _to_binary(str) == byte_str
+    assert _to_string(byte_str) == str
+    assert _to_string(str) == str
+    assert _to_binary(byte_str) == byte_str
+    assert _to_string(u_str) == u_str
+
+
+def test_unicode_regression(app):
+    """Test legacy encryption with Unicode encoding."""
+    with app.app_context():
+        user = create_legacy_user(password=u'κωδικός')
+        assert verify_password(u'κωδικός', user.password)
+
+
+def test_invenio_aes_encrypted_email(app):
+    """Test legacy encryption."""
+    with app.app_context():
+        ctx = flask.current_app.extensions['security'].pwd_context
+        user = create_legacy_user()
+        assert verify_password(user.password_plaintext, user.password)
+        assert ctx.needs_update(user.password)
+
+
+def test_user_login(app):
+    """Test users' high-level login process."""
+    with app.app_context():
+        user = create_test_user()
+        with app.test_client() as client:
+            login_user_via_view(client, user.email, user.password_plaintext)
+            assert client_authenticated(client)
+
+
+def test_legacy_user_login(app):
+    """Test legacy users' high-level login process."""
+    with app.app_context():
+        user = create_legacy_user()
+        old_hashval = user.password
+        with app.test_client() as client:
+            login_user_via_view(client, user.email, user.password_plaintext)
+            # Verify user is authenticated
+            assert client_authenticated(client)
+            # Verify password hash is upgraded
+            ds = flask.current_app.extensions['security'].datastore
+            user2 = ds.find_user(email=user.email)
+            assert old_hashval != user2.password
+
+
+def test_monkey_patch(app):
+    """Test monkey-patching of Flask-Security's get_hmac function."""
+    with app.app_context():
+        user = create_test_user()
+        assert verify_password(user.password_plaintext, user.password)
+
+
+def test_monkey_patch_legacy(app):
+    """Test monkey-patching of Flask-Security's get_hmac function."""
+    with app.app_context():
+        user = create_legacy_user()
+        assert verify_password(user.password_plaintext, user.password)
+
+
+def create_legacy_user(email='test@test.org', password=u'qwert1234', **kwargs):
+    """Create a legacy user in the datastore.
+
+    A legacy user's password has been encrypted with the legacy mechanism,
+    namely 'invenio_aes_encrypted_email'.
+    """
+    assert flask.current_app.testing
+    ds = flask.current_app.extensions['security'].datastore
+
+    # Encrypt password
+    ctx = flask.current_app.extensions['security'].pwd_context
+    encrypted_password = ctx.encrypt(
+        password,
+        scheme="invenio_aes_encrypted_email",
+        salt=email,
+    )
+
+    # Update datastore
+    user = ds.create_user(email=email, password=encrypted_password, **kwargs)
+    ds.commit()
+    user.password_plaintext = password
+
+    return user


### PR DESCRIPTION
 * NEW Adds the ability to migrate legacy Invenio users to Invenio 3
 automatically. The old encryption scheme has been integrated into the
 flask-security extension and a `migrate_hash` function can be used to
 update the password by re-encrypting it (using the current hash
 scheme) and storing it in the datastore. (closes #122)

 * Adds a new test utility, namely `create_legacy_user`.

 * Increases test coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>
Co-Authored-By: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>