### PR TITLE
views: allow CHANGEABLE to be False

### DIFF
--- a/invenio_accounts/views.py
+++ b/invenio_accounts/views.py
@@ -63,28 +63,32 @@ def post_ext_init(state):
 @blueprint.before_app_first_request
 def init_menu():
     """Initialize menu before first request."""
+    changeable = current_app.config.get('SECURITY_CHANGEABLE', True)
+
     # Register breadcrumb root
     item = current_menu.submenu('breadcrumbs.settings')
     item.register('', _('Account'))
     item = current_menu.submenu('breadcrumbs.{0}'.format(
         current_app.config['SECURITY_BLUEPRINT_NAME']))
-    item.register('', _('Change password'))
+    if changeable:
+        item.register('', _('Change password'))
 
-    # Register settings menu
-    item = current_menu.submenu('settings.change_password')
-    item.register(
-        "{0}.change_password".format(
-            current_app.config['SECURITY_BLUEPRINT_NAME']),
-        # NOTE: Menu item text (icon replaced by a user icon).
-        _('%(icon)s Change password', icon='<i class="fa fa-key fa-fw"></i>'),
-        order=1)
+        # Register settings menu
+        item = current_menu.submenu('settings.change_password')
+        item.register(
+            "{0}.change_password".format(
+                current_app.config['SECURITY_BLUEPRINT_NAME']),
+            # NOTE: Menu item text (icon replaced by a user icon).
+            _('%(icon)s Change password',
+                icon='<i class="fa fa-key fa-fw"></i>'),
+            order=1)
 
-    # Register breadcrumb
-    item = current_menu.submenu('breadcrumbs.{0}.change_password'.format(
-        current_app.config['SECURITY_BLUEPRINT_NAME']))
-    item.register(
-        "{0}.change_password".format(
-            current_app.config['SECURITY_BLUEPRINT_NAME']),
-        _("Change password"),
-        order=0,
-    )
+        # Register breadcrumb
+        item = current_menu.submenu('breadcrumbs.{0}.change_password'.format(
+            current_app.config['SECURITY_BLUEPRINT_NAME']))
+        item.register(
+            "{0}.change_password".format(
+                current_app.config['SECURITY_BLUEPRINT_NAME']),
+            _("Change password"),
+            order=0,
+        )


### PR DESCRIPTION
 * FIX Fixes issue of `change_password` registration, even when the
   configuration `variable SECURITY_CHANGEABLE` was set to `False`.