### PR TITLE
views: allow CHANGEABLE to be False

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,13 +27,15 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
 
 
-def _warn_node(self, msg, node):
+_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
+
+
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/invenio_accounts/views.py
+++ b/invenio_accounts/views.py
@@ -68,23 +68,26 @@ def init_menu():
     item.register('', _('Account'))
     item = current_menu.submenu('breadcrumbs.{0}'.format(
         current_app.config['SECURITY_BLUEPRINT_NAME']))
-    item.register('', _('Change password'))
 
-    # Register settings menu
-    item = current_menu.submenu('settings.change_password')
-    item.register(
-        "{0}.change_password".format(
-            current_app.config['SECURITY_BLUEPRINT_NAME']),
-        # NOTE: Menu item text (icon replaced by a user icon).
-        _('%(icon)s Change password', icon='<i class="fa fa-key fa-fw"></i>'),
-        order=1)
+    if current_app.config.get('SECURITY_CHANGEABLE', True):
+        item.register('', _('Change password'))
 
-    # Register breadcrumb
-    item = current_menu.submenu('breadcrumbs.{0}.change_password'.format(
-        current_app.config['SECURITY_BLUEPRINT_NAME']))
-    item.register(
-        "{0}.change_password".format(
-            current_app.config['SECURITY_BLUEPRINT_NAME']),
-        _("Change password"),
-        order=0,
-    )
+        # Register settings menu
+        item = current_menu.submenu('settings.change_password')
+        item.register(
+            "{0}.change_password".format(
+                current_app.config['SECURITY_BLUEPRINT_NAME']),
+            # NOTE: Menu item text (icon replaced by a user icon).
+            _('%(icon)s Change password',
+                icon='<i class="fa fa-key fa-fw"></i>'),
+            order=1)
+
+        # Register breadcrumb
+        item = current_menu.submenu('breadcrumbs.{0}.change_password'.format(
+            current_app.config['SECURITY_BLUEPRINT_NAME']))
+        item.register(
+            "{0}.change_password".format(
+                current_app.config['SECURITY_BLUEPRINT_NAME']),
+            _("Change password"),
+            order=0,
+        )


### PR DESCRIPTION
 * FIX Fixes issue of `change_password` registration, even when the
   configuration `variable SECURITY_CHANGEABLE` was set to `False`.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>