### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Accounts.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-accounts
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/app.py
+++ b/examples/app.py
@@ -52,8 +52,8 @@ Create a user:
 
 .. code-block:: console
 
-   $ flask users create info@invenio-software.org -a
-   $ flask users activate info@invenio-software.org
+   $ flask users create info@inveniosoftware.org -a
+   $ flask users activate info@inveniosoftware.org
 
 Run the development server:
 

--- a/invenio_accounts/translations/da/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/da/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-11-10 15:53+0100\n"
 "PO-Revision-Date: 2015-10-13 17:58+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_accounts/translations/messages.pot
+++ b/invenio_accounts/translations/messages.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.0.0a2\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-11-10 15:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = invenio_accounts/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_accounts/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
     keywords='invenio accounts',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-accounts',
     packages=packages,
     zip_safe=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ def test_cli_createuser(script_info):
     # Create user
     result = runner.invoke(
         users_create,
-        ['info@invenio-software.org', '--password', '123456'],
+        ['info@inveniosoftware.org', '--password', '123456'],
         obj=script_info
     )
     assert result.exit_code == 0

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -109,13 +109,13 @@ def test_datastore_usercreate(app):
     ds = app.extensions['invenio-accounts'].datastore
 
     with app.app_context():
-        u1 = ds.create_user(email='info@invenio-software.org', password='1234',
+        u1 = ds.create_user(email='info@inveniosoftware.org', password='1234',
                             active=True)
         ds.commit()
-        u2 = ds.find_user(email='info@invenio-software.org')
+        u2 = ds.find_user(email='info@inveniosoftware.org')
         assert u1 == u2
         assert 1 == \
-            User.query.filter_by(email='info@invenio-software.org').count()
+            User.query.filter_by(email='info@inveniosoftware.org').count()
 
 
 def test_datastore_rolecreate(app):
@@ -136,12 +136,12 @@ def test_datastore_assignrole(app):
     ds = app.extensions['invenio-accounts'].datastore
 
     with app.app_context():
-        u = ds.create_user(email='info@invenio-software.org', password='1234',
+        u = ds.create_user(email='info@inveniosoftware.org', password='1234',
                            active=True)
         r = ds.create_role(name='superuser', description='1234')
         ds.add_role_to_user(u, r)
         ds.commit()
-        u = ds.get_user('info@invenio-software.org')
+        u = ds.get_user('info@inveniosoftware.org')
         assert len(u.roles) == 1
         assert u.roles[0].name == 'superuser'
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -49,7 +49,7 @@ def test_no_log_in_message_for_logged_in_users(app):
         assert log_in_message in resp.data
         assert sign_up_message in resp.data
 
-        test_email = 'info@invenio-software.org'
+        test_email = 'info@inveniosoftware.org'
         test_password = 'test1234'
         resp = client.post(url_for_security('register'), data=dict(
             email=test_email,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>