### PR TITLE
tests: user creation with required email address

### DIFF
--- a/invenio_accounts/testutils.py
+++ b/invenio_accounts/testutils.py
@@ -45,8 +45,7 @@ from werkzeug.local import LocalProxy
 _datastore = LocalProxy(lambda: current_app.extensions['security'].datastore)
 
 
-def create_test_user(email='test@test.org',
-                     password='123456', **kwargs):
+def create_test_user(email, password='123456', **kwargs):
     """Create a user in the datastore, bypassing the registration process.
 
     Accesses the application's datastore. An error is thrown if called from

--- a/tests/e2e/e2e_basic_test.py
+++ b/tests/e2e/e2e_basic_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -76,7 +76,7 @@ def test_user_registration(live_server, env_browser):
     input_password = signup_form.find_element_by_name('password')
     # input w/ name "email"
     # input w/ name "password"
-    user_email = 'test@test.org'
+    user_email = 'test@example.org'
     user_password = '12345_SIx'
     input_email.send_keys(user_email)
     input_password.send_keys(user_password)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -104,7 +104,7 @@ def test_invenio_aes_encrypted_email(app):
 def test_user_login(app):
     """Test users' high-level login process."""
     with app.app_context():
-        user = create_test_user()
+        user = create_test_user('test@example.org')
         with app.test_client() as client:
             login_user_via_view(client, user.email, user.password_plaintext)
             assert client_authenticated(client)
@@ -128,7 +128,7 @@ def test_legacy_user_login(app):
 def test_monkey_patch(app):
     """Test monkey-patching of Flask-Security's get_hmac function."""
     with app.app_context():
-        user = create_test_user()
+        user = create_test_user('test@example.org')
         assert verify_password(user.password_plaintext, user.password)
 
 
@@ -139,7 +139,8 @@ def test_monkey_patch_legacy(app):
         assert verify_password(user.password_plaintext, user.password)
 
 
-def create_legacy_user(email='test@test.org', password=u'qwert1234', **kwargs):
+def create_legacy_user(email='test@example.org', password=u'qwert1234',
+                       **kwargs):
     """Create a legacy user in the datastore.
 
     A legacy user's password has been encrypted with the legacy mechanism,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,7 +41,7 @@ def test_session_activity_model(app):
         inspector = inspect(db.engine)
         assert 'accounts_user_session_activity' in inspector.get_table_names()
 
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
 
         # Create a new SessionActivity object, put it in the db
         session_activity = SessionActivity(user_id=user.get_id(),

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -48,7 +48,7 @@ def test_login_listener(app):
     """Test login listener."""
     with app.app_context():
         with app.test_client() as client:
-            user = testutils.create_test_user()
+            user = testutils.create_test_user('test@example.org')
             # The SessionActivity table is initially empty
             query = db.session.query(SessionActivity)
             assert query.count() == 0
@@ -73,7 +73,7 @@ def test_repeated_login_session_population(app):
     sessions in the kv-store, when logging in with one user.
     """
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
         query = db.session.query(SessionActivity)
         assert query.count() == len(app.kvsession_store.keys())
 
@@ -102,7 +102,7 @@ def test_repeated_login_session_population(app):
 def test_login_multiple_clients_single_user_session_population(app):
     """Test session population/creation from multiple clients for same user."""
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
 
         client_count = 3
         clients = [app.test_client() for _ in range(client_count)]
@@ -142,7 +142,7 @@ def test_sessionstore_default_ttl_secs(app):
     app.kvsession_store = sessionstore
 
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
 
         with app.test_client() as client:
             testutils.login_user_via_view(client, user=user)
@@ -174,7 +174,7 @@ def test_session_ttl(app):
     assert app.permanent_session_lifetime.total_seconds() == ttl_seconds
 
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
 
         with app.test_client() as client:
             testutils.login_user_via_view(client, user=user)
@@ -203,7 +203,7 @@ def test_repeated_login_session_expiration(app):
     app.config['PERMANENT_SESSION_LIFETIME'] = ttl_delta
 
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
         with app.test_client() as client:
             testutils.login_user_via_view(client, user=user)
             first_sid_s = session.sid_s
@@ -221,7 +221,7 @@ def test_repeated_login_session_expiration(app):
 def test_session_deletion(app):
     """Test if user is not authenticated when session is deleted."""
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
 
         with app.test_client() as client:
             testutils.login_user_via_view(client, user=user)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,7 +42,7 @@ def test_client_authenticated(app):
     authenticated/logged in.
     """
     ds = app.extensions['security'].datastore
-    email = 'test@test.org'
+    email = 'test@example.org'
     password = '123456'
 
     with app.app_context():
@@ -89,12 +89,12 @@ def test_client_authenticated(app):
 
 
 def test_create_test_user(app):
-    """Test for testutils.py:create_test_user().
+    """Test for testutils.py:create_test_user('test@example.org').
 
     Demonstrates basic usage and context requirements.
     """
     ds = app.extensions['security'].datastore
-    email = 'test@test.org'
+    email = 'test@example.org'
     password = '1234'
 
     with app.app_context():
@@ -120,7 +120,7 @@ def test_create_test_user(app):
 def test_create_test_user_defaults(app):
     """Test the default values for testutils.py:create_test_user."""
     with app.app_context():
-        user = testutils.create_test_user()
+        user = testutils.create_test_user('test@example.org')
         with app.test_client() as client:
             testutils.login_user_via_view(client, user.email,
                                           user.password_plaintext)
@@ -129,7 +129,7 @@ def test_create_test_user_defaults(app):
 
 def test_login_user_via_view(app):
     """Test the login-via-view function/hack."""
-    email = 'test@test.org'
+    email = 'test@example.org'
     password = '1234'
 
     with app.app_context():
@@ -143,7 +143,7 @@ def test_login_user_via_view(app):
 
 def test_login_user_via_session(app):
     """Test the login-via-view function/hack."""
-    email = 'test@test.org'
+    email = 'test@example.org'
     password = '1234'
 
     with app.app_context():


### PR DESCRIPTION
* Makes email address a required argument in `create_test_user`
  function.  (closes #93)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>