### PR TITLE
global: Flask-WTF upgrade to 0.13

### DIFF
--- a/invenio_accounts/forms.py
+++ b/invenio_accounts/forms.py
@@ -27,11 +27,11 @@
 Currently supported: recaptcha
 """
 from flask_babelex import gettext as _
-from flask_wtf import Form, Recaptcha, RecaptchaField
+from flask_wtf import FlaskForm, Recaptcha, RecaptchaField
 from wtforms import FormField
 
 
-class RegistrationFormRecaptcha(Form):
+class RegistrationFormRecaptcha(FlaskForm):
     """Form for editing user profile."""
 
     recaptcha = RecaptchaField(validators=[

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ install_requires = [
     'Flask-Login>=0.3.0',
     'Flask-Menu>=0.4.0',
     'Flask-Security>=1.7.5',
+    'Flask-WTF>=0.13.0',
     'SQLAlchemy-Utils[ipaddress]>=0.31.0',
     'cryptography>=1.3',
     'redis>=2.10.5',


### PR DESCRIPTION
We just began seeing this warning:
```
class ChangePasswordForm(Form, PasswordFormMixin):
    /Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/invenio_accounts/forms.py:34:
    FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be
    removed in 1.0.
```

This PR bumps `Flask-WTF` to 0.13 and updates the API correspondingly to suppress this warning.