### PR TITLE
admin: session administration addition, session creation on sign-up

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -25,6 +25,8 @@
 
 u"""Minimal Flask application example for development.
 
+Run Redis server.
+
 Install the Invenio default theme
 
 You should execute these commands in the examples-directory.

--- a/examples/templates/authenticated.html
+++ b/examples/templates/authenticated.html
@@ -5,6 +5,8 @@
   </head>
   <body>
     You are logged in.
-    <a href="{{url_for_security('logout')}}">Log out</a>
+    <a href="{{url_for_security('logout')}}">Log out</a>.</br>
+    Go to my <a href="{{url_for_security('change_password')}}">account page</a>.<br>
+    Go to <a href="{{url_for('admin.index')}}">admin page</a>.
   </body>
 </html>

--- a/invenio_accounts/admin.py
+++ b/invenio_accounts/admin.py
@@ -203,8 +203,7 @@ class SessionActivityView(ModelView):
     }
 
     def delete_model(self, model):
-        is_current = SessionActivity.is_current(sid_s=model.sid_s)
-        if is_current:
+        if SessionActivity.is_current(sid_s=model.sid_s):
             flash('You could not remove your current session', 'error')
             return
         delete_session(sid_s=model.sid_s)

--- a/invenio_accounts/sessions.py
+++ b/invenio_accounts/sessions.py
@@ -73,6 +73,7 @@ def login_listener(app, user):
         # Save the session first so that the sid_s gets generated.
         app.session_interface.save_session(app, flask.session, response)
         add_session(flask.session)
+        current_accounts.datastore.commit()
         return response
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extras_require = {
         'celery>=3.1.0,<4.0',
     ],
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx>=1.4.2,<1.6',
     ],
     'mysql': [
         'invenio-db[versioning,mysql]>=1.0.0b3',
@@ -130,6 +130,8 @@ setup(
         'invenio_admin.views': [
             'invenio_accounts_user = invenio_accounts.admin:user_adminview',
             'invenio_accounts_role = invenio_accounts.admin:role_adminview',
+            'invenio_accounts_session = '
+            'invenio_accounts.admin:session_adminview',
         ],
         'invenio_base.api_apps': [
             'invenio_accounts_rest = invenio_accounts:InvenioAccountsREST',


### PR DESCRIPTION
* Adds a session administration page. (addresses #52)

* Commits the session when login permit to fix the session creation
  on user first signup. (closes #190)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>