### PR TITLE
installation: celery task entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,9 @@ setup(
         'invenio_base.blueprints': [
             'invenio_accounts = invenio_accounts.views:blueprint',
         ],
+        'invenio_celery.tasks': [
+            'invenio_accounts = invenio_accounts.tasks',
+        ],
         'invenio_db.alembic': [
             'invenio_accounts = invenio_accounts:alembic',
         ],


### PR DESCRIPTION
* Fixes issue with Celery task not being registered.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>