### PR TITLE
templates: empty session check in security.html

### DIFF
--- a/invenio_accounts/templates/invenio_accounts/settings/security.html
+++ b/invenio_accounts/templates/invenio_accounts/settings/security.html
@@ -50,7 +50,7 @@
       <b>{{_("Session identifier")}}:</b> {{session.sid_s}}<br />
       <small>
         {{_("Signed in")}}:
-        {{session.created | tousertimezone | dateformat}}
+        {% if session %}{{session.created | tousertimezone | dateformat}}{% endif %}
         {% if is_current_sid %}<span class="text-muted">(current session)</span>{% endif %}
       </small>
     </div>


### PR DESCRIPTION
* Fixes 500 error when visiting security page
  immediately after signing up

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>