### PR TITLE
global: delete session after logout request

### DIFF
--- a/invenio_accounts/sessions.py
+++ b/invenio_accounts/sessions.py
@@ -82,12 +82,11 @@ def logout_listener(app, user):
     :param app: The Flask application.
     :param user: The :class:`invenio_accounts.models.User` instance.
     """
-    delete_session(flask.session.sid_s)
-    # Regenerate the session to avoid session fixation vulnerabilities.
-    flask.session.regenerate()
-
     @flask.after_this_request
     def _commit(response=None):
+        delete_session(flask.session.sid_s)
+        # Regenerate the session to avoid session fixation vulnerabilities.
+        flask.session.regenerate()
         current_accounts.datastore.commit()
         return response
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,6 +22,5 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+https://github.com/inveniosoftware/flask-security-fork.git#egg=flask-security-fork
 -e git+https://github.com/inveniosoftware/invenio-db.git#egg=invenio-db
 -e git+https://github.com/maxcountryman/flask-login.git#egg=flask-login

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,6 @@ output-dir = invenio_accounts/translations/
 [update_catalog]
 input-file = invenio_accounts/translations/messages.pot
 output-dir = invenio_accounts/translations/
+
+[pydocstyle]
+add_ignore = D401


### PR DESCRIPTION
* Fixes logout issue in tests by deleting the user session in an
  after_this_request function instead of doing it immediately.
  (closes #197)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>