### PR TITLE
global: addition of JWT

### DIFF
--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -24,6 +24,8 @@
 
 """Default configuration for ACCOUNTS."""
 
+from datetime import timedelta
+
 ACCOUNTS = True
 """Tells if the templates should use the accounts module.
 
@@ -215,3 +217,72 @@ SECURITY_CHANGE_URL = '/account/settings/password/'
    <https://pythonhosted.org/Flask-Security/configuration.html>`_
    configuration.
 """
+
+ACCOUNTS_JWT_ENABLE = True
+"""Enable JWT support.
+
+.. note::
+
+    More details about `JWT <https://jwt.io>`_
+"""
+
+ACCOUNTS_JWT_DOM_TOKEN = True
+"""Register JTW context processor.
+
+.. code-block:: html
+
+    {% if current_user.is_authenticated %}
+        {{ jwt() }}
+    {% endif %}
+
+This will generate a ``hidden`` field as follows:
+
+.. code-block:: html
+
+    <input type="hidden" name="authorized_token" value="xxx">
+
+On your API call you can use it with simple javascript, an example using
+``jQuery`` is the following:
+
+.. code-block:: javascript
+
+    $.ajax({
+        url: '/example',
+        method: 'POST',
+        beforeSend: function(request) {
+            request.setRequestHeader(
+                'Authorization',
+                'Bearer ' + $('[name=authorized_token]').val()
+            );
+        },
+    });
+"""
+
+ACCOUNTS_JWT_DOM_TOKEN_TEMPLATE = 'invenio_accounts/jwt.html'
+"""Template for the context processor."""
+
+ACCOUNTS_JWT_SECRET_KEY = None
+"""Secret key for JWT.
+
+.. note::
+
+    If is set to ``None`` it will use the ``SECRET_KEY``.
+"""
+
+ACCOUNTS_JWT_EXPIRATION_DELTA = timedelta(days=1)
+"""Token expiration period for JWT."""
+
+ACCOUNTS_JWT_ALOGORITHM = 'HS256'
+"""Set JWT encryption alogirthm.
+
+.. note::
+
+   `Available aglorithms
+   <https://pyjwt.readthedocs.io/en/latest/algorithms.html>`_
+"""
+
+ACCOUNTS_JWT_DECODE_FACTORY = 'invenio_accounts.utils:jwt_decode_token'
+"""Import path of factory used to decode JWT."""
+
+ACCOUNTS_JWT_CREATION_FACTORY = 'invenio_accounts.utils:jwt_create_token'
+"""Import path of factory used to generate JWT."""

--- a/invenio_accounts/context_processors/__init__.py
+++ b/invenio_accounts/context_processors/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Context processors instances."""
+
+from __future__ import absolute_import, print_function

--- a/invenio_accounts/context_processors/jwt.py
+++ b/invenio_accounts/context_processors/jwt.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""JWT context processors."""
+
+from flask import current_app, render_template
+from jinja2 import Markup
+
+from ..proxies import current_accounts
+
+
+def jwt_proccessor():
+    """Context processor for jwt."""
+    def jwt():
+        """Context processor function to generate jwt."""
+        token = current_accounts.jwt_creation_factory()
+        return Markup(
+            render_template(
+                current_app.config['ACCOUNTS_JWT_DOM_TOKEN_TEMPLATE'],
+                token=token
+            )
+        )
+    return {
+        'jwt': jwt
+    }

--- a/invenio_accounts/errors.py
+++ b/invenio_accounts/errors.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Utility function for ACCOUNTS."""
+
+
+class JWTExtendedException(Exception):
+    """Base exception for all JWT errors."""
+
+
+class JWTDecodeError(JWTExtendedException):
+    """Exception raised when decoding is failed."""
+
+
+class JWTExpiredToken(JWTExtendedException):
+    """Exception raised when JWT is expired."""

--- a/invenio_accounts/templates/invenio_accounts/jwt.html
+++ b/invenio_accounts/templates/invenio_accounts/jwt.html
@@ -1,0 +1,24 @@
+{#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
+<input type='hidden' name='authorized_token' value='{{ token }}' />

--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Utility function for ACCOUNTS."""
+
+import uuid
+from datetime import datetime
+
+from flask import current_app
+from flask_login import current_user
+from future.utils import raise_from
+from jwt import DecodeError, ExpiredSignatureError, decode, encode
+
+from .errors import JWTDecodeError, JWTExpiredToken
+
+
+def jwt_create_token(user_id=None, additional_data=None):
+    """Encode the JWT token.
+
+    :param int user_id: Addition of user_id.
+    :param dict additional_data: Additional information for the token.
+    :returns: The encoded token.
+    :rtype: str
+
+    .. note::
+        Definition of the JWT claims:
+
+        * exp: ((Expiration Time) expiration time of the JWT.
+        * sub: (subject) the principal that is the subject of the JWT.
+        * jti: (JWT ID) UID for the JWT.
+    """
+    # Create an ID
+    uid = str(uuid.uuid4())
+    # The time in UTC now
+    now = datetime.utcnow()
+    # Build the token data
+    token_data = {
+        'exp': now + current_app.config['ACCOUNTS_JWT_EXPIRATION_DELTA'],
+        'sub': user_id or current_user.get_id(),
+        'jti': uid,
+    }
+    # Add any additional data to the token
+    if additional_data is not None:
+        token_data.update(additional_data)
+
+    # Encode the token and send it back
+    encoded_token = encode(
+        token_data,
+        current_app.config['ACCOUNTS_JWT_SECRET_KEY'],
+        current_app.config['ACCOUNTS_JWT_ALOGORITHM']
+    ).decode('utf-8')
+    return encoded_token
+
+
+def jwt_decode_token(token):
+    """Decode the JWT token.
+
+    :param str token: Additional information for the token.
+    :returns: The token data.
+    :rtype: dict
+    """
+    try:
+        return decode(
+            token,
+            current_app.config['ACCOUNTS_JWT_SECRET_KEY'],
+            algorithms=[
+                current_app.config['ACCOUNTS_JWT_ALOGORITHM']
+            ]
+        )
+    except DecodeError as exc:
+        raise_from(JWTDecodeError(), exc)
+    except ExpiredSignatureError as exc:
+        raise_from(JWTExpiredToken(), exc)

--- a/setup.py
+++ b/setup.py
@@ -94,10 +94,12 @@ install_requires = [
     'Flask-Security-Fork>=1.8.0',
     'Flask-WTF>=0.13.0',
     'Flask>=0.11.1',
+    'future>=0.16.0',
     'SQLAlchemy-Utils[ipaddress]>=0.31.0',
     'cryptography>=1.3',
     'invenio-i18n>=1.0.0b2',
     'maxminddb-geolite2>=2017.404',
+    'pyjwt>=1.5.0',
     'redis>=2.10.5',
     'ua-parser>=0.7.3',
 ]

--- a/tests/test_template_context_processors.py
+++ b/tests/test_template_context_processors.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Tests for template context processors."""
+
+from __future__ import absolute_import, print_function
+
+from flask import render_template_string
+
+
+def test_context_processor_jwt(app):
+    """Test context processor JWT."""
+    template = r"""
+    {{ jwt() }}
+    """
+    with app.test_request_context():
+        html = render_template_string(template)
+        assert 'authorized_token' in html


### PR DESCRIPTION
* Adds support for JWT (jwt.io), which is enabled by default. All the
  protected endpoints ``require_api_auth`` will be automatically
  check for JWT in the headers. A token can be generated by using the
  ``{{ jwt() }}`` context processor in jinja templates and can
  be send with each API request.

Signed-off-by: Harris Tzovanakis <me@drjova.com>