### PR TITLE
models: fix alembic foreign key naming

### DIFF
--- a/invenio_accounts/alembic/9848d0149abd_create_accounts_tables.py
+++ b/invenio_accounts/alembic/9848d0149abd_create_accounts_tables.py
@@ -94,8 +94,7 @@ def upgrade():
         batch_op.add_column(sa.Column(
             'user_id',
             sa.Integer(),
-            sa.ForeignKey(
-                'accounts_user.id', name='fk_transaction_accounts_user_id'),
+            sa.ForeignKey('accounts_user.id'),
             nullable=True,
         ))
         batch_op.create_index(


### PR DESCRIPTION
* Fixes a bug where the name of the foreign key constraint between
  the "transaction" table and the "accounts_user" table was random.
  (closes #219)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>