### PR TITLE
security: secure by default configuration

### DIFF
--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -137,6 +137,10 @@ SECURITY_LOGOUT_URL = '/logout/'
 SECURITY_CHANGE_URL = '/account/settings/password/'
 """URL endpoint for password change."""
 
+REMEMBER_COOKIE_DURATION = timedelta(days=90)
+"""Remember me cookie life time changed to 90 days instead of 365 days."""
+
+# JWT related config
 ACCOUNTS_JWT_ENABLE = True
 """Enable JWT support.
 

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -218,11 +218,37 @@ class InvenioAccounts(object):
         # Register Invenio legacy password hashing
         register_crypt_handler(InvenioAesEncryptedEmail)
 
-        # Change Flask-Security defaults
-        app.config.setdefault('SECURITY_PASSWORD_SALT',
-                              app.config['SECRET_KEY'])
+        # Change Flask defaults
+        app.config.setdefault(
+            'SESSION_COOKIE_SECURE',
+            not app.debug
+        )
 
-        # Set secret key
+        # Change Flask-Security defaults
+        app.config.setdefault(
+            'SECURITY_PASSWORD_SALT',
+            app.config['SECRET_KEY']
+        )
+
+        # Set default values for remember me cookie to same as session cookie.
+        app.config.setdefault(
+            'REMEMBER_COOKIE_HTTPONLY',
+            app.config.get('SESSION_COOKIE_HTTPONLY')
+        )
+
+        app.config.setdefault(
+            'REMEMBER_COOKIE_SECURE',
+            app.config.get('SESSION_COOKIE_SECURE')
+        )
+
+        # Note, SESSION_COOKIE_DOMAIN must be explicitly set otherwise the
+        # cookie domain for the remember me cookie will not be set.
+        app.config.setdefault(
+            'REMEMBER_COOKIE_DOMAIN',
+            app.config.get('SESSION_COOKIE_DOMAIN'),
+        )
+
+        # Set JWT secret key
         app.config.setdefault(
             'ACCOUNTS_JWT_SECRET_KEY',
             app.config.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,8 @@ def _database_setup(app, request):
 
     def teardown():
         with app.app_context():
-            drop_database(str(db.engine.url))
+            if database_exists(str(db.engine.url)):
+                drop_database(str(db.engine.url))
             # Delete sessions in kvsession store
             if hasattr(app, 'kvsession_store') and \
                     isinstance(app.kvsession_store, RedisStore):
@@ -134,6 +135,18 @@ def task_app(request):
         MAIL_SUPPRESS_SEND=True,
     ))
     FlaskCeleryExt(app)
+    InvenioAccounts(app)
+    _database_setup(app, request)
+    return app
+
+
+@pytest.fixture
+def cookie_app(request):
+    """Flask application  enabled."""
+    app = _app_factory(dict(
+        SESSION_COOKIE_SECURE=True,
+        SESSION_COOKIE_DOMAIN='example.com',
+    ))
     InvenioAccounts(app)
     _database_setup(app, request)
     return app


### PR DESCRIPTION
 * Add secure default config for "remember me" -cookie.
   By default matches mostly to configuration of session-cookie.

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>