### PR TITLE
SQLAlchemy-Utils extras fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0b5 (released 2017-07-07)
+Version 1.0.0b6 (released 2017-07-25)
 -------------------------------------
 
 - Module rewrite using Flask-Security(-Fork).

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ===========================
- Invenio-Accounts v1.0.0b5
+ Invenio-Accounts v1.0.0b6
 ===========================
 
-Invenio-Accounts v1.0.0b5 was released on July 7, 2017.
+Invenio-Accounts v1.0.0b6 was released on July 25, 2017.
 
 About
 -----
@@ -17,7 +17,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-accounts==1.0.0b5
+   $ pip install invenio-accounts==1.0.0b6
 
 Documentation
 -------------

--- a/invenio_accounts/version.py
+++ b/invenio_accounts/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0b5"
+__version__ = "1.0.0b6"

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,9 @@ install_requires = [
     'Flask-WTF>=0.13.0',
     'Flask>=0.11.1',
     'future>=0.16.0',
-    'SQLAlchemy-Utils[ipaddress]>=0.31.0',
+    # Not using 'ipaddress' extras for SQLALchemy-Utils in favor of
+    # direct 'ipaddr' version marker (issues with Python3 builds on Travis).
+    'SQLAlchemy-Utils>=0.31.0',
     'cryptography>=1.3',
     'invenio-i18n>=1.0.0b2',
     'maxminddb-geolite2>=2017.404',


### PR DESCRIPTION
Solves installation issues on Python3 and Travis:
https://travis-ci.org/zenodo/zenodo/jobs/257306470#L1391

This was most likely because of some travis pip cache issue and/or requirements-builder.

The version marker which install ipaddr directly on Python 2 produces the same effect as the removed extras kwarg: https://github.com/kvesteri/sqlalchemy-utils/blob/master/setup.py#L47