### PR TITLE
global: encrypt_password -> hash_password

### DIFF
--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -32,7 +32,7 @@ import click
 from flask import current_app
 from flask.cli import with_appcontext
 from flask_security.forms import ConfirmRegisterForm
-from flask_security.utils import encrypt_password
+from flask_security.utils import hash_password
 from werkzeug.datastructures import MultiDict
 from werkzeug.local import LocalProxy
 
@@ -71,7 +71,7 @@ def users_create(email, password, active):
     form = ConfirmRegisterForm(MultiDict(kwargs), csrf_enabled=False)
 
     if form.validate():
-        kwargs['password'] = encrypt_password(kwargs['password'])
+        kwargs['password'] = hash_password(kwargs['password'])
         kwargs['active'] = active
         _datastore.create_user(**kwargs)
         click.secho('User created successfully.', fg='green')

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -58,13 +58,13 @@ def get_hmac(password):
     return _to_binary(password)
 
 
-def encrypt_password(password):
-    """Override Flask-Security's default encryption function.
+def hash_password(password):
+    """Override Flask-Security's default hashing function.
 
     :param password: The plain password.
-    :returns: The encrypted password.
+    :returns: The hashed password.
     """
-    return current_app.extensions['security'].pwd_context.encrypt(password)
+    return current_app.extensions['security'].pwd_context.hash(password)
 
 
 class InvenioAccounts(object):
@@ -87,11 +87,11 @@ class InvenioAccounts(object):
         """Monkey-patch Flask-Security."""
         if utils.get_hmac != get_hmac:
             utils.get_hmac = get_hmac
-        if utils.encrypt_password != encrypt_password:
-            utils.encrypt_password = encrypt_password
-            changeable.encrypt_password = encrypt_password
-            recoverable.encrypt_password = encrypt_password
-            registerable.encrypt_password = encrypt_password
+        if utils.hash_password != hash_password:
+            utils.hash_password = hash_password
+            changeable.hash_password = hash_password
+            recoverable.hash_password = hash_password
+            registerable.hash_password = hash_password
 
     def load_obj_or_import_string(self, value):
         """Import string or return object.

--- a/invenio_accounts/testutils.py
+++ b/invenio_accounts/testutils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -38,7 +38,7 @@ import flask_login
 from flask import current_app
 from flask_kvsession import SessionID
 from flask_security import url_for_security
-from flask_security.utils import encrypt_password
+from flask_security.utils import hash_password
 from werkzeug.local import LocalProxy
 
 # "Convenient references" (lifted from flask_security source)
@@ -59,8 +59,8 @@ def create_test_user(email, password='123456', **kwargs):
     :returns: A :class:`invenio_accounts.models.User` instance.
     """
     assert flask.current_app.testing
-    encrypted_password = encrypt_password(password)
-    user = _datastore.create_user(email=email, password=encrypted_password,
+    hashed_password = hash_password(password)
+    user = _datastore.create_user(email=email, password=hashed_password,
                                   **kwargs)
     _datastore.commit()
     user.password_plaintext = password

--- a/setup.py
+++ b/setup.py
@@ -86,13 +86,13 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask-BabelEx>=0.9.2',
+    'Flask-BabelEx>=0.9.3',
     'Flask-Breadcrumbs>=0.3.0',
     'Flask-KVSession>=0.6.1',
     'Flask-Login>=0.3.0',
     'Flask-Menu>=0.4.0',
-    'Flask-Security-Fork>=1.8.0',
-    'Flask-WTF>=0.13.0',
+    'Flask-Security>=3.0.0',
+    'Flask-WTF>=0.13.1',
     'Flask>=0.11.1',
     'future>=0.16.0',
     # Not using 'ipaddress' extras for SQLALchemy-Utils in favor of

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -24,8 +24,8 @@
 
 import pytest
 from flask import current_app, session, url_for
-from flask.ext.security.utils import encrypt_password
 from flask_admin import menu
+from flask_security.utils import hash_password
 from invenio_admin import InvenioAdmin
 from invenio_db import db
 from werkzeug.local import LocalProxy
@@ -49,7 +49,7 @@ def test_admin(app, admin_view):
         # create user and save url for testing
         request_url = url_for("user.action_view")
         kwargs = dict(email="test@test.cern", active=False,
-                      password=encrypt_password('aafaf4as5fa'))
+                      password=hash_password('aafaf4as5fa'))
         _datastore.create_user(**kwargs)
         _datastore.commit()
         inserted_id = _datastore.get_user('test@test.cern').id
@@ -123,15 +123,15 @@ def test_admin_createuser(app, admin_view):
         assert user.active is False
 
     user_data = dict(email='test4@test.cern', active=False,
-                     password=encrypt_password('123456'))
+                     password=hash_password('123456'))
     _datastore.create_user(**user_data)
 
     user_data = dict(email='test5@test.cern', active=True,
-                     password=encrypt_password('123456'))
+                     password=hash_password('123456'))
     _datastore.create_user(**user_data)
 
     user_data = dict(email='test6@test.cern', active=False,
-                     password=encrypt_password('123456'))
+                     password=hash_password('123456'))
     _datastore.create_user(**user_data)
     _datastore.commit()
     assert _datastore.get_user('test4@test.cern') is not None

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,7 +30,7 @@ from binascii import hexlify, unhexlify
 
 import flask
 import pytest
-from flask_security.utils import encrypt_password, verify_password
+from flask_security.utils import hash_password, verify_password
 
 from invenio_accounts.hash import _to_binary, _to_string, mysql_aes_decrypt, \
     mysql_aes_encrypt
@@ -66,11 +66,11 @@ def test_context(app):
     """Test passlib password context."""
     with app.app_context():
         ctx = flask.current_app.extensions['security'].pwd_context
-        hashval = encrypt_password("test")
+        hashval = hash_password("test")
         assert hashval != "test"
         assert verify_password("test", hashval)
         assert not ctx.needs_update(hashval)
-        assert ctx.encrypt("test") != ctx.encrypt("test")
+        assert ctx.hash("test") != ctx.hash("test")
 
 
 def test_conversion():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -31,7 +31,7 @@ from datetime import datetime
 import flask_login
 import pytest
 from flask_security import url_for_security
-from flask_security.utils import encrypt_password
+from flask_security.utils import hash_password
 from invenio_db import db
 
 from invenio_accounts import testutils
@@ -71,7 +71,7 @@ def test_client_authenticated(app):
             assert response.location is None
 
             # Create a user manually directly in the datastore
-            ds.create_user(email=email, password=encrypt_password(password))
+            ds.create_user(email=email, password=hash_password(password))
             db.session.commit()
 
             # Manual login via view


### PR DESCRIPTION
Same motivation as https://github.com/inveniosoftware/flask-security-fork/pull/28, but different implementation: here I'm not deprecating `encrypt_password`, I'm outright removing it.

Consequently, I switch from `Flask-Security-Fork` to `Flask-Security>=3.0.0`, which is guaranteed to contain the commit I introduced above. The other two changes in `setup.py` are required to match the minimal version of the packages required by `Flask-Security>=3.0.0`.