### PR TITLE
ext: disable remember me token generation and login from header

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -100,11 +100,12 @@ class InvenioAccounts(object):
             pass
         LoginManager._set_cookie = patch_do_nothing
 
-        # Disable loading user from header because we want to be sure we
-        # can load user only through the login form.
+        # Disable loading user from headers and object because we want to be
+        # sure we can load user only through the login form.
         def patch_reload_anonym(self, *args, **kwargs):
             self.reload_user()
         LoginManager._load_from_header = patch_reload_anonym
+        LoginManager._load_from_request = patch_reload_anonym
 
     def load_obj_or_import_string(self, value):
         """Import string or return object.

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -96,9 +96,15 @@ class InvenioAccounts(object):
         # Disable remember me cookie generation as it does not work with
         # session activity tracking (a remember me token will bypass revoking
         # of  a session).
-        def patch_set_cookie(*args, **kwargs):
+        def patch_do_nothing(*args, **kwargs):
             pass
-        LoginManager._set_cookie = patch_set_cookie
+        LoginManager._set_cookie = patch_do_nothing
+
+        # Disable loading user from header because we want to be sure we
+        # can load user only through the login form.
+        def patch_reload_anonym(self, *args, **kwargs):
+            self.reload_user()
+        LoginManager._load_from_header = patch_reload_anonym
 
     def load_obj_or_import_string(self, value):
         """Import string or return object.

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -181,9 +181,6 @@ def test_cookies(cookie_app, users):
     """Test cookies set on login."""
     u = users[0]
 
-    with cookie_app.app_context():
-        login_url = url_for_security('login')
-
     with cookie_app.test_client() as client:
         res = client.post(
             url_for_security('login'),
@@ -192,7 +189,7 @@ def test_cookies(cookie_app, users):
         assert res.status_code == 302
         cookies = {c.name: c for c in client.cookie_jar}
         assert 'session' in cookies
-        assert 'remember_token' in cookies
+        assert 'remember_token' not in cookies
 
         # Cookie must be HTTP only, secure and have a domain specified.
         for c in cookies.values():
@@ -200,5 +197,3 @@ def test_cookies(cookie_app, users):
             assert c.domain_specified is True, 'no domain in {}'.format(c.name)
             assert c.has_nonstandard_attr('HttpOnly')
             assert c.secure is True
-
-        assert cookies['session'].domain == cookies['remember_token'].domain


### PR DESCRIPTION
* Disables remember me token generation. (closes #226)

* Disables login from headers. 

* Disables login from request. (closes #231)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>