### PR TITLE
setup: upper bound for ``idna``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,8 @@ install_requires = [
     'SQLAlchemy-Utils>=0.31.0',
     'cryptography>=1.3',
     'invenio-i18n>=1.0.0b2',
+    # Until the next ``requests`` is released
+    'idna>=2.1,<2.6',
     'maxminddb-geolite2>=2017.404',
     'passlib>=1.7.1',
     'pyjwt>=1.5.0',


### PR DESCRIPTION
* Adds an upper bound version ``2.6`` for ``idna`` module until the next
  ``requests`` is released. More details are in the following commit
  https://github.com/requests/requests/commit/f4ddf00c364e4396e7d941f91a8817311dd79adc
  which support ``2.6`` version. (closes inveniosoftware/invenio-app-ils#33)

Signed-off-by: Harris Tzovanakis <me@drjova.com>