### PR TITLE
sessions: don't require sid_s to be there

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0b10 (released 2017-09-15)
+Version 1.0.0b11 (released 2017-12-13)
 --------------------------------------
 
 - Module rewrite using Flask-Security(-Fork).

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ============================
- Invenio-Accounts v1.0.0b10
+ Invenio-Accounts v1.0.0b11
 ============================
 
-Invenio-Accounts v1.0.0b10 was released on September 15, 2017.
+Invenio-Accounts v1.0.0b11 was released on December 13, 2017.
 
 About
 -----
@@ -17,7 +17,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-accounts==1.0.0b10
+   $ pip install invenio-accounts==1.0.0b11
 
 Documentation
 -------------

--- a/invenio_accounts/sessions.py
+++ b/invenio_accounts/sessions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -113,7 +113,8 @@ def logout_listener(app, user):
     """
     @after_this_request
     def _commit(response=None):
-        delete_session(session.sid_s)
+        if hasattr(session, 'sid_s'):
+            delete_session(session.sid_s)
         # Regenerate the session to avoid session fixation vulnerabilities.
         session.regenerate()
         current_accounts.datastore.commit()

--- a/invenio_accounts/version.py
+++ b/invenio_accounts/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0b10"
+__version__ = "1.0.0b11"

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     # Not using 'ipaddress' extras for SQLALchemy-Utils in favor of
     # direct 'ipaddr' version marker (issues with Python3 builds on Travis).
     'SQLAlchemy-Utils>=0.31.0',
-    'cryptography>=1.3',
+    'cryptography>=2.1.4',
     'invenio-i18n>=1.0.0b4',
     'maxminddb-geolite2>=2017.404',
     'passlib>=1.7.1',


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-accounts/issues/247.

First commit bumps the minimum version of `cryptography`
to the version required by the version of `OpenSSL` that is
there (see: https://github.com/pyca/pyopenssl/issues/728).

In Flask-KVSession, a session without a ``sid_s`` attribute is
equivalent to one that set it to ``None``, so we shouldn't be
assuming that it's there (see: https://github.com/mbr/flask-kvsession/commit/a04957d91d1a9146e3b83445c10d9e5273365af3).

Last commit asks for a release, as this is a bug we're seeing
on a production system : )