### PR TITLE
ext: set kvsessionstore at config loading

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,7 +321,10 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'https://docs.python.org/': None,
+    'http://pythonhosted.org/simplekv': None,
+}
 
 # Autodoc configuraton.
 autoclass_content = 'both'

--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -16,10 +16,13 @@ ACCOUNTS = True
 If False, you won't be able to login via the web UI.
 """
 
-ACCOUNTS_SESSION_REDIS_URL = 'redis://localhost:6379/0'
+ACCOUNTS_SESSION_REDIS_URL = ''
 """Redis URL used by the module as a cache system for sessions.
 
 It should be in the form ``redis://username:password@host:port/db_index``.
+When set, Invenio-Accounts will use Redis as KV session store
+:class:`simplekv.memory.redisstore.RedisStore`, otherwise it will default to
+in memory backend :class:`simplekv.memory.DictStore`.
 """
 
 ACCOUNTS_REGISTER_BLUEPRINT = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,13 @@ def _app_factory(config=None):
         TESTING=True,
         WTF_CSRF_ENABLED=False,
     )
+
+    # Set key value session store to use Redis when running on TravisCI.
+    if os.environ.get('CI', 'false') == 'true':
+        app.config.update(
+            ACCOUNTS_SESSION_REDIS_URL='redis://localhost:6379/0',
+        )
+
     app.config.update(config or {})
     Menu(app)
     Babel(app)

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -10,6 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
+import os
+
 import pytest
 from flask import Flask
 from flask_babelex import Babel
@@ -181,3 +183,14 @@ def test_cookies(cookie_app, users):
             assert c.domain_specified is True, 'no domain in {}'.format(c.name)
             assert c.has_nonstandard_attr('HttpOnly')
             assert c.secure is True
+
+
+def test_kvsession_store_init(app):
+    """Test KV session configuration was loaded correctly."""
+    if os.environ.get('CI', 'false') == 'true':
+        from simplekv.memory.redisstore import \
+            RedisStore as kvsession_store_class
+    else:
+        from simplekv.memory import DictStore as kvsession_store_class
+
+    assert isinstance(app.kvsession_store, kvsession_store_class)


### PR DESCRIPTION
* Updates configuration setting ACCOUNTS_SESSION_REDIS_URL to
  empty string by default, what makes Invenio-Accounts use in memory
  store. Documentation updated accordingly.

* Configures test application to use Redis when running on travis
  builds (closes #266).