### PR TITLE
templates: Use SETTINGS_TEMPLATE as parent template

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -238,6 +238,12 @@ class InvenioAccounts(object):
             )
         )
 
+        # Follow SETTINGS_TEMPLATE pattern
+        app.config.setdefault(
+            'ACCOUNTS_SETTINGS_TEMPLATE',
+            app.config.get('SETTINGS_TEMPLATE',
+                           'invenio_accounts/settings/base.html'))
+
         config_apps = ['ACCOUNTS', 'SECURITY_']
         for k in dir(config):
             if any([k.startswith(prefix) for prefix in config_apps]):


### PR DESCRIPTION
By following this pattern used by invenio-gitub,
invenio-userprofiles and so on, the parent template of
invenio_accounts/settings/security.html can be overriden
in one location.