### PR TITLE
global: update dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.1.3 (released 2020-02-19)
+
+- Replaces Flask-CeleryExt to invenio-celery due to version incompatibilities
+  with celery, kombu. Removes Flask-BabelExt already provided by invenio-i18n
+
 Version 1.1.2 (released 2020-02-12)
 
 - Fixes requirements for Flask, Werkzeug and Flask-Login due to

--- a/invenio_accounts/version.py
+++ b/invenio_accounts/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,6 @@ extras_require = {
     'admin': [
         'Flask-Admin>=1.3.0',
     ],
-    'celery': [
-        # Needed for building the documentation until v4.2 is released.
-        'celery>=3.1.0,<4.0',
-    ],
     'docs': [
         'Sphinx>=1.4.2,<1.6',
     ],
@@ -69,9 +65,7 @@ setup_requires = [
 
 install_requires = [
     'cryptography>=2.1.4',
-    'Flask-BabelEx>=0.9.3',
     'Flask-Breadcrumbs>=0.4.0',
-    'Flask-CeleryExt>=0.3.1',
     'Flask-KVSession>=0.6.1',
     'Flask-Login>=0.3.0,<0.5.0',
     'Flask-Mail>=0.9.1',
@@ -81,6 +75,7 @@ install_requires = [
     'Flask>=1.0.4',
     'future>=0.16.0',
     'invenio-i18n>=1.0.0',
+    'invenio-celery>=1.1.2',
     'maxminddb-geolite2>=2017.404',
     'passlib>=1.7.1',
     'pyjwt>=1.5.0',


### PR DESCRIPTION
* replaces flask-celeryext with invenio-celery
* removes Flask-BabelEx already required by invenio-i18n