### PR TITLE
dependencies: fix missing email_validator [more]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,19 @@
 Changes
 =======
 
+Version 1.2.1 (released 2020-04-28)
+
+- Fixes issue with the latest WTForms v2.3.x release which now requires an
+  extra library for email validation.
+
 Version 1.2.0 (released 2020-03-09)
 
 - Replaces Flask dependency with centrally managed invenio-base
+
+Version 1.1.4 (released 2020-04-28)
+
+- Fixes issue with the latest WTForms v2.3.x release which now requires an
+  extra library for email validation.
 
 Version 1.1.3 (released 2020-02-19)
 

--- a/invenio_accounts/version.py
+++ b/invenio_accounts/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
     'mock>=2.0.0',
     'pydocstyle>=1.0.0',
     'pytest-cov>=1.8.0',
-    'pytest-flask>=0.10.0',
+    'pytest-flask>=0.10.0,<1.0.0',
     'pytest-pep8>=1.0.6',
     'pytest>=4.0.0,<5.0.0',
     'selenium>=3.0.1',
@@ -72,6 +72,7 @@ install_requires = [
     'Flask-Menu>=0.5.0',
     'Flask-Security>=3.0.0',
     'Flask-WTF>=0.14.3',
+    'email-validator>=1.0.5',
     'future>=0.16.0',
     'invenio-base>=1.2.2',
     'invenio-i18n>=1.2.0',
@@ -85,7 +86,7 @@ install_requires = [
     # Not using 'ipaddress' extras for SQLALchemy-Utils in favor of
     # direct 'ipaddr' version marker (issues with Python3 builds on Travis).
     'SQLAlchemy-Utils>=0.31.0',
-    'ua-parser>=0.7.3',
+    'ua-parser>=0.7.3'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
This is a 'quick' fix for the 2.3.1 breaking change in wtforms
that requires the email-validator library. WTForms is brought in
from flask-security and flask-security is a dependency of
invenio-accounts.

The real fix would be switching to [flask-security-too](https://wtforms.readthedocs.io) since
flask-security is not maintained anymore. However, a cursory attempt
has generated more errors. So until we can address those errors,
this fix can do. (things like `security.forgot_password` not resolving to a route...)

- also fixes pytest dependency issues