### PR TITLE
rest: remove password length validation from login

### DIFF
--- a/invenio_accounts/views/rest.py
+++ b/invenio_accounts/views/rest.py
@@ -201,8 +201,7 @@ class LoginView(MethodView, UserViewMixin):
 
     post_args = {
         'email': fields.Email(required=True, validate=[user_exists]),
-        'password': fields.String(
-            required=True, validate=[validate.Length(min=6, max=128)])
+        'password': fields.String(required=True)
     }
 
     def success_response(self, user):

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -91,9 +91,9 @@ def test_login_view(api):
 
             # Invalid fields
             res = client.post(url, data=dict(
-                email='invalid-email', password='short'))
+                email='invalid-email', password=None))
             assert_error_resp(res, (
-                ('password', 'length'),
+                ('password', 'required field'),
                 ('email', 'not a valid email'),
             ))
 


### PR DESCRIPTION
This validation makes sense when registering but not when logging in.