### PR TITLE
translations: remove fuzzy

### DIFF
--- a/invenio_accounts/translations/cs/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/cs/LC_MESSAGES/messages.po
@@ -3,8 +3,7 @@
 # This file is distributed under the same license as the invenio-accounts
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
-# 
-#, fuzzy
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.0.0a14.dev20160704\n"

--- a/invenio_accounts/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/de/LC_MESSAGES/messages.po
@@ -3,8 +3,7 @@
 # This file is distributed under the same license as the invenio-accounts
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
-# 
-#, fuzzy
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.0.0a14.dev20160704\n"

--- a/invenio_accounts/translations/es/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/es/LC_MESSAGES/messages.po
@@ -4,7 +4,6 @@
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.0.0a14.dev20160704\n"

--- a/invenio_accounts/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/fr/LC_MESSAGES/messages.po
@@ -3,8 +3,7 @@
 # This file is distributed under the same license as the invenio-accounts
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
-# 
-#, fuzzy
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.0.0a14.dev20160704\n"

--- a/invenio_accounts/translations/it/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/it/LC_MESSAGES/messages.po
@@ -3,8 +3,7 @@
 # This file is distributed under the same license as the invenio-accounts
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
-# 
-#, fuzzy
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.0.0a14.dev20160704\n"

--- a/invenio_accounts/translations/messages.pot
+++ b/invenio_accounts/translations/messages.pot
@@ -4,7 +4,6 @@
 # This file is distributed under the same license as the invenio-accounts
 # project.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.4.0a5\n"

--- a/invenio_accounts/translations/tr/LC_MESSAGES/messages.po
+++ b/invenio_accounts/translations/tr/LC_MESSAGES/messages.po
@@ -3,11 +3,10 @@
 # Copyright (C) 2020 TUBITAK
 # This file is distributed under the same license as the invenio-accounts
 # project.
-# 
+#
 # Translators:
 # Berat Aldemir <berataldemir@gmail.com>, 2020
-# 
-#, fuzzy
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-accounts 1.4.0a5\n"


### PR DESCRIPTION
Closes #346 

The strings were manually removed. However, when created the `fuzzy` string is added. Another option is to force transifex to include fuzzy (add `-f` flag, see [here](https://github.com/inveniosoftware/invenio-app-rdm/issues/230)).

There are [173 files with this problem in Invenio](https://github.com/search?q=org%3Ainveniosoftware+fuzzy&type=code), @lnielsen maybe we could somehow use the automation tools to remove this line?