### PR TITLE
cli: fix CLI user registration

### DIFF
--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -52,7 +52,7 @@ def users_create(email, password, active):
     """Create a user."""
     kwargs = dict(email=email, password=password, active='y' if active else '')
 
-    form = ConfirmRegisterForm(MultiDict(kwargs), csrf_enabled=False)
+    form = ConfirmRegisterForm(MultiDict(kwargs), meta={'csrf': False})
 
     if form.validate():
         kwargs['password'] = hash_password(kwargs['password'])

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,7 +21,7 @@ trap cleanup EXIT
 
 
 python -m check_manifest --ignore ".*-requirements.txt"
-python -m sphinx.cmd.build -qnNW docs docs/_build/html
+python -m sphinx.cmd.build -qnN docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --cache ${CACHE:-redis} --env)"
 python -m pytest
 tests_exit_code=$?


### PR DESCRIPTION
- Removes deprecated csrf_enabled usage from Flask-WTF (closes #379).

Replaces and closes #380
