### PR TITLE
models: add user profiles as a validated json field

### DIFF
--- a/invenio_accounts/alembic/eb9743315a9d_add_userprofile.py
+++ b/invenio_accounts/alembic/eb9743315a9d_add_userprofile.py
@@ -1,0 +1,77 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Add user profile and preferences as JSON fields to the User table."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy_utils.types import JSONType
+
+# revision identifiers, used by Alembic.
+revision = "eb9743315a9d"
+down_revision = "62efc52773d4"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.add_column(
+        "accounts_user",
+        sa.Column(
+            "profile",
+            sa.JSON()
+            .with_variant(JSONType(), "mysql")
+            .with_variant(
+                postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
+                "postgresql",
+            )
+            .with_variant(JSONType(), "sqlite"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "accounts_user",
+        sa.Column(
+            "preferences",
+            sa.JSON()
+            .with_variant(JSONType(), "mysql")
+            .with_variant(
+                postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
+                "postgresql",
+            )
+            .with_variant(JSONType(), "sqlite"),
+            nullable=True,
+        ),
+    )
+
+    # the user name is split into two columns:
+    # 'displayname' which stores the original version of the username, and
+    # 'username' which stores a lower-case version to ensure uniqueness
+    op.add_column(
+        "accounts_user",
+        sa.Column("displayname", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "accounts_user",
+        sa.Column("username", sa.String(length=255), nullable=True),
+    )
+    op.create_unique_constraint(
+        op.f("uq_accounts_user_username"), "accounts_user", ["username"]
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_column("accounts_user", "preferences")
+    op.drop_column("accounts_user", "profile")
+    op.drop_constraint(
+        op.f("uq_accounts_user_username"), "accounts_user", type_="unique"
+    )
+    op.drop_column("accounts_user", "displayname")
+    op.drop_column("accounts_user", "username")

--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -11,6 +11,7 @@
 
 from datetime import timedelta
 
+from .profiles import UserPreferencesSchema, UserProfileSchema
 from .views import login
 
 ACCOUNTS = True
@@ -306,3 +307,26 @@ left as is.
 
 ACCOUNTS_LOCAL_LOGIN_ENABLED = True
 """Whether or not login with local account credentials should be enabled."""
+
+ACCOUNTS_USER_PREFERENCES_SCHEMA = UserPreferencesSchema()
+"""The schema to use for validation of the user preferences."""
+
+ACCOUNTS_USER_PROFILE_SCHEMA = UserProfileSchema()
+"""The schema to use for validation of the user profile."""
+
+ACCOUNTS_USERNAME_REGEX = r"^[a-zA-Z][a-zA-Z0-9-_]{2,255}$"
+"""The regular expression used for validating usernames.
+
+.. note:: When this configuration value is overridden, the value for
+          ``ACCOUNTS_USERNAME_RULES_TEXT`` should be updated as well,
+          to reflect the changes.
+"""
+
+ACCOUNTS_USERNAME_RULES_TEXT = (
+    'Username must start with a letter, be at least three characters long and'
+    ' only contain alphanumeric characters, dashes and underscores.'
+)
+"""Description of username validation rules.
+
+.. note:: Used for both form help text and for form validation error.
+"""

--- a/invenio_accounts/profiles/__init__.py
+++ b/invenio_accounts/profiles/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Utilities for validation of user profiles and preferences."""
+
+from .dicts import UserPreferenceDict, UserProfileDict, ValidatedDict
+from .schemas import UserPreferencesSchema, UserProfileSchema
+
+__all__ = (
+    "UserPreferenceDict",
+    "UserPreferencesSchema",
+    "UserProfileDict",
+    "UserProfileSchema",
+    "ValidatedDict",
+)

--- a/invenio_accounts/profiles/dicts.py
+++ b/invenio_accounts/profiles/dicts.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Validated dictionary classes for user profiles and preferences."""
+
+from inspect import isclass
+
+from invenio_base.utils import load_or_import_from_config
+from marshmallow import ValidationError
+
+
+class ValidatedDict(dict):
+    """A dictionary class that validates itself when properties are set."""
+
+    def __init__(self, schema, *args, **kwargs):
+        """Constructor, validates the given data."""
+        self._schema = schema() if isclass(schema) else schema
+        self._validate(dict(*args, **kwargs))
+        super().__init__(*args, **kwargs)
+
+    def _validate(self, data):
+        """Validate the data with the dictionary's schema."""
+        try:
+            if self._schema is not None:
+                # without schema, we basically revert to a normal dictionary
+                # with more overhead
+                self._schema.load(data)
+        except ValidationError as error:
+            raise ValueError(f"Validation failed: {error}")
+
+    def _try_op(self, op_name, *args, **kwargs):
+        """Try the named operation and see if it violates the schema."""
+        data = {**self}
+        getattr(data, op_name)(*args, **kwargs)
+        self._validate(data)
+
+    def clear(self):
+        """Remove all items from the dictionary."""
+        self._validate({})
+        return super().clear()
+
+    def pop(self, key, default=None):
+        """Remove specified key and return the corresponding value."""
+        self._try_op("pop", key, default)
+        return super().pop(key, default)
+
+    def popitem(self, *args, **kwargs):
+        """Remove and return a (key, value) pair as a 2-tuple."""
+        self._try_op("popitem", *args, **kwargs)
+        return super().popitem(*args, **kwargs)
+
+    def update(self, e, **f):
+        """Update the dict from dict/iterable e and f."""
+        self._try_op("update", e, **f)
+        return super().update(e, **f)
+
+    def setdefault(self, key, default=None):
+        """Insert key with a value of default if key is not in the dict."""
+        self._try_op("setdefault", key, default)
+        return super().setdefault(key, default)
+
+    def __setitem__(self, key, value):
+        """Validate the dictionary and set the value if successful."""
+        data = {**self, key: value}
+        self._validate(data)
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        """Validate the dictionary and delete the key if successful."""
+        data = {**self}
+        del data[key]
+        self._validate(data)
+        super().__delitem__(key)
+
+
+class UserProfileDict(ValidatedDict):
+    """Dictionary that validates itself against the user profile schema."""
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        schema = load_or_import_from_config("ACCOUNTS_USER_PROFILE_SCHEMA")
+        super().__init__(schema, **kwargs)
+
+
+class UserPreferenceDict(ValidatedDict):
+    """Dictionary that validates itself against the preference schema."""
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        schema = load_or_import_from_config("ACCOUNTS_USER_PREFERENCES_SCHEMA")
+        super().__init__(schema, **kwargs)

--- a/invenio_accounts/profiles/schemas.py
+++ b/invenio_accounts/profiles/schemas.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Schemas for user profiles and preferences."""
+
+
+from marshmallow import Schema, fields
+
+
+class UserProfileSchema(Schema):
+    """The default user profile schema."""
+
+    full_name = fields.String()
+
+
+class UserPreferencesSchema(Schema):
+    """The default schema for user preferences."""

--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -8,11 +8,13 @@
 
 """Utility function for ACCOUNTS."""
 
+import re
 import uuid
 from datetime import datetime
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from flask import current_app, request, session, url_for
+from flask_babelex import lazy_gettext as _
 from flask_security import current_user
 from flask_security.confirmable import generate_confirmation_token
 from flask_security.recoverable import generate_reset_password_token
@@ -191,3 +193,18 @@ def change_user_password(_reset_password_link_func=None, **user_data):
                   reset_password_link=reset_password_link)
     password_changed.send(current_app._get_current_object(),
                           user=user)
+
+
+def validate_username(username):
+    """Validate the username.
+
+    :param username: The username to validate.
+    :raises ValueError: If validation fails.
+    """
+    username_regex = current_app.config["ACCOUNTS_USERNAME_REGEX"]
+
+    if not re.fullmatch(username_regex, username):
+        # if validation fails, we raise a ValueError with the configured
+        # text explaining the validation rules.
+        message = _(current_app.config["ACCOUNTS_USERNAME_RULES_TEXT"])
+        raise ValueError(message)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,17 +2,26 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C)      2022 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test invenio-accounts models."""
 
+import pytest
 from invenio_db import db
+from marshmallow import Schema, fields
 from sqlalchemy import inspect
 
 from invenio_accounts import testutils
-from invenio_accounts.models import SessionActivity
+from invenio_accounts.models import SessionActivity, User
+
+
+class CustomProfile(Schema):
+    """A custom user profile schema."""
+
+    file_descriptor = fields.Integer(strict=True)
 
 
 def test_session_activity_model(app):
@@ -65,3 +74,60 @@ def test_session_activity_model(app):
         database.session.commit()
         assert len(user.active_sessions) == 1
         assert user.active_sessions[0].sid_s != session_to_delete.sid_s
+
+
+def test_user_profiles(app):
+    """Test the user profile."""
+    user = User(email="admin@inveniosoftware.org")
+    profile = {
+        "full_name": "Invenio Admin",
+    }
+
+    with pytest.raises(ValueError):
+        # the profile doesn't expect an 'email' value
+        user.user_profile = {
+            **profile, "email": "admin@inveniosoftware.org",
+        }
+
+    assert user.user_profile is None
+
+    # a valid profile should be accepted
+    user.user_profile = profile
+    assert dict(user.user_profile) == profile
+
+    # setting expected properties should work
+    assert len(user.user_profile) == 1
+    assert user.user_profile["full_name"] == "Invenio Admin"
+
+    # but setting unexpected properties should not work
+    with pytest.raises(ValueError):
+        user.user_profile["invalid"] = "value"
+
+    # similar with wrong types for expected fields
+    with pytest.raises(ValueError):
+        user.user_profile["email"] = 1
+
+    assert len(user.user_profile) == 1
+    assert user.user_profile["full_name"] == "Invenio Admin"
+
+
+def test_custom_user_profiles(app):
+    """Test if the customization mechanism for user profiles works."""
+    app.config["ACCOUNTS_USER_PROFILE_SCHEMA"] = CustomProfile()
+    user = User(email="admin@inveniosoftware.org")
+
+    # the default fields aren't allowed in the custom schema
+    with pytest.raises(ValueError):
+        user.user_profile = {
+            "full_name": "Invenio Admin",
+        }
+
+    # the expected properties should work...
+    user.user_profile = {"file_descriptor": 1}
+    assert dict(user.user_profile) == {"file_descriptor": 1}
+
+    # ... but not with unexpected types!
+    with pytest.raises(ValueError):
+        user.user_profile["file_descriptor"] = "1"
+
+    assert dict(user.user_profile) == {"file_descriptor": 1}

--- a/tests/test_validated_dicts.py
+++ b/tests/test_validated_dicts.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C)      2022 TU Wien.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for the user profile utilities."""
+
+import pytest
+from marshmallow import Schema, fields
+
+from invenio_accounts.profiles.dicts import ValidatedDict
+
+
+class RequiredFieldSchema(Schema):
+    """Schema with one optional and one required field."""
+
+    optional = fields.String(required=False)
+    required = fields.String(required=True)
+
+
+class OptionalFieldsSchema(Schema):
+    """Schema with only one optional field."""
+
+    optional = fields.String()
+
+
+def test_validated_dict_required_fields():
+    """Test if the removal of required fields fails."""
+    # we can leave out the optional field
+    dictionary = ValidatedDict(RequiredFieldSchema, required="ok")
+    assert "required" in dictionary
+    assert "optional" not in dictionary
+
+    # removal of the required field shouldn't work...
+    with pytest.raises(ValueError):
+        dictionary.pop("required", None)
+
+    with pytest.raises(ValueError):
+        del dictionary["required"]
+
+    with pytest.raises(ValueError):
+        dictionary.clear()
+
+    # we can't leave out the required field
+    with pytest.raises(ValueError):
+        ValidatedDict(RequiredFieldSchema, optional="ok")
+
+
+def test_validated_dict_optional_fields():
+    """Test if we can delete optional fields."""
+    # test a few ways of deleting optional fields
+    dictionary = ValidatedDict(OptionalFieldsSchema, optional="ok")
+    assert dictionary
+    dictionary.pop("optional", None)
+    assert not dictionary
+
+    dictionary = ValidatedDict(OptionalFieldsSchema, optional="ok")
+    del dictionary["optional"]
+    assert not dictionary
+
+    dictionary = ValidatedDict(OptionalFieldsSchema, optional="ok")
+    dictionary.clear()
+    assert not dictionary
+
+    dictionary = ValidatedDict(OptionalFieldsSchema, optional="ok")
+
+
+def test_validated_dict():
+    """A few general tests for the validated dictionary."""
+    # unexpected values should raise an error
+    with pytest.raises(ValueError):
+        ValidatedDict(OptionalFieldsSchema, required="ok")
+
+    # setting wrong types should raise an error
+    with pytest.raises(ValueError):
+        ValidatedDict(OptionalFieldsSchema, optional=123)
+
+    # update should work...
+    dictionary = ValidatedDict(OptionalFieldsSchema)
+    assert "optional" not in dictionary
+    dictionary.update({"optional": "yes"})
+    assert dictionary["optional"] == "yes"
+
+    # ... but not with a wrong type
+    with pytest.raises(ValueError):
+        dictionary.update({"optional": False})
+
+    # setdefault should work as expected
+    dictionary = ValidatedDict(RequiredFieldSchema, required="ok")
+    assert "optional" not in dictionary
+    dictionary.setdefault("optional", "yes")
+    assert dictionary["optional"] == "yes"
+    dictionary.setdefault("optional", "no")
+    assert dictionary["optional"] == "yes"
+
+    # setting values per key should also work
+    dictionary["required"] = "absolutely"
+    assert dictionary["required"] == "absolutely"
+    with pytest.raises(ValueError):
+        dictionary["required"] = None


### PR DESCRIPTION
In this pull request, we introduce JSON-based fields for user profiles, which use configurable marshmallow schemas for validation of manipulation operations before their actual execution.
While this introduces additional overhead for each of the manipulation operations, we do not think that this should be a big issue because updates to user profiles are a rare operation.
Investigations showed that other Invenio modules would often use the `User` model directly rather than helpers like the datastore (e.g. to query for users), and it would thus be beneficial to not introduce extra API functions for user manipulation.

This PR enables operations like the following on users:
```python
In [6]: user.user_profile = {"full_name": "Max Moser", "username": "max-moser"}

In [7]: user.user_profile
Out[7]: {'full_name': 'Max Moser', 'username': 'max-moser'}

In [8]: user.user_profile = {"full_name": "Max Moser", "username": "max-moser", "email": "max@tuwien.ac.at"}

# ... stack trace omitted

ValueError: Validation failed: {'email': ['Unknown field.']}

In [9]: user.user_profile["email"] = "max@tuwien.ac.at"

# ... stack trace omitted

ValueError: Validation failed: {'email': ['Unknown field.']}

In [10]: user.user_profile
Out[10]: {'full_name': 'Max Moser', 'username': 'max-moser'}
```

Note that this PR does not perform any data migration from the tables defined by Invenio-UserProfiles.