### PR TITLE
register: option to avoid sending e-mail

### DIFF
--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -151,7 +151,7 @@ def default_confirmation_link_func(user):
     return token, _generate_token_url(endpoint, token)
 
 
-def register_user(_confirmation_link_func=None, **user_data):
+def register_user(_confirmation_link_func=None, send_register_msg=True, **user_data):
     """Register a user."""
     confirmation_link_func = _confirmation_link_func or default_confirmation_link_func
     if user_data.get("password") is not None:
@@ -167,7 +167,7 @@ def register_user(_confirmation_link_func=None, **user_data):
         current_app._get_current_object(), user=user, confirm_token=token
     )
 
-    if security_config_value("SEND_REGISTER_EMAIL"):
+    if send_register_msg and security_config_value("SEND_REGISTER_EMAIL"):
         send_mail(
             security_config_value("EMAIL_SUBJECT_REGISTER"),
             user.email,

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,9 @@ mysql =
 sqlite =
     invenio-db>=1.0.14
 tests =
-    pytest-black>=0.3.0,<0.3.10
+    mock>=1.3.0
     invenio-app>=1.3.3
+    pytest-black>=0.3.0
     pytest-invenio>=1.4.6
     sphinx>=4.2.0,<5
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@
 from datetime import datetime
 
 import flask_login
+import mock
 import pytest
 from flask_security import url_for_security
 from flask_security.utils import hash_password
@@ -18,7 +19,7 @@ from invenio_db import db
 
 from invenio_accounts import testutils
 from invenio_accounts.errors import JWTDecodeError, JWTExpiredToken
-from invenio_accounts.utils import jwt_create_token, jwt_decode_token
+from invenio_accounts.utils import jwt_create_token, jwt_decode_token, register_user
 
 
 def test_client_authenticated(app):
@@ -169,3 +170,16 @@ def test_jwt_expired_token(app):
         # Random token
         with pytest.raises(JWTDecodeError):
             jwt_decode_token("Roadster SV")
+
+
+@mock.patch("invenio_accounts.utils.send_mail")
+def test_register_user_send_mail(mock_send_mail, app):
+    """Test register_user send mail."""
+    with app.app_context():
+        register_user(send_register_msg=True, email="test1@test.org", password="1234")
+        mock_send_mail.assert_called_once()
+
+        mock_send_mail.reset_mock()
+
+        register_user(send_register_msg=False, email="test2@test.org", password="1234")
+        mock_send_mail.assert_not_called()


### PR DESCRIPTION
* adds a new option to fine tune when to send the registration e-mail and not relying only on the global security configuration.