### PR TITLE
wip: change roles db table

### DIFF
--- a/invenio_accounts/alembic/8f11b75e0995_change_accountsrole_primary_key_to_.py
+++ b/invenio_accounts/alembic/8f11b75e0995_change_accountsrole_primary_key_to_.py
@@ -1,0 +1,52 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Change AccountsRole primary key to string."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8f11b75e0995'
+down_revision = 'eb9743315a9d'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    # Drop foreign key and change type
+    op.drop_constraint("fk_accounts_userrole_role_id", "accounts_userrole", type_="foreignkey")
+    op.alter_column('accounts_userrole', 'role_id', existing_type=sa.Integer, type_=sa.String(80))
+    # Change primary key type
+    op.drop_constraint('pk_accounts_role', 'accounts_role', type_='primary')
+    # server_default=None will remove the autoincrement
+    op.alter_column('accounts_role', 'id', existing_type=sa.Integer, type_=sa.String(80), server_default=None)
+    op.execute('DROP SEQUENCE accounts_role_id_seq')
+    op.create_primary_key('pk_accounts_role', 'accounts_role', ['id'])
+    # Add new column `is_managed`
+    op.add_column('accounts_role', sa.Column('is_managed', sa.Boolean(name='is_managed'), default=True, nullable=False))
+    # Re-create the foreign key constraint
+    op.create_foreign_key('fk_accounts_userrole_role_id', 'accounts_userrole', 'accounts_role', ['role_id'], ['id'])
+
+
+def downgrade():
+    """Downgrade database."""
+    # Drop foreign key and change type
+    op.drop_constraint("fk_accounts_userrole_role_id", "accounts_userrole", type_="foreignkey")
+    op.alter_column('accounts_userrole', 'role_id', existing_type=sa.String(80), type_=sa.Integer)
+    # Change primary key type
+    op.drop_constraint('pk_accounts_role', 'accounts_role', type_='primary')
+    op.alter_column('accounts_role', 'id', existing_type=sa.String(80), type_=sa.Integer)
+    op.create_primary_key('pk_accounts_role', 'accounts_role', ['id'])
+    op.alter_column('accounts_role', 'id', existing_type=sa.Integer, autoincrement=True, existing_autoincrement=True, nullable=False)
+    # Drop new column `is_managed`
+    op.drop_column('accounts_role', 'is_managed')
+    # Re-create the foreign key constraint
+    op.create_foreign_key('fk_accounts_userrole_role_id', 'accounts_userrole', 'accounts_role', ['role_id'], ['id'])
+

--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -63,13 +63,16 @@ class Role(db.Model, Timestamp, RoleMixin):
 
     __tablename__ = "accounts_role"
 
-    id = db.Column(db.Integer(), primary_key=True)
+    id = db.Column(db.String(80), primary_key=True)
 
     name = db.Column(db.String(80), unique=True)
     """Role name."""
 
     description = db.Column(db.String(255))
     """Role description."""
+
+    is_managed = db.Column(db.Boolean(name="is_managed"), default=True, nullable=False)
+    """True when the role is managed by Invenio, and not externally provided."""
 
     # Enables SQLAlchemy version counter
     version_id = db.Column(db.Integer, nullable=False)


### PR DESCRIPTION
* changes the roles table to use a `string` primary key instead of an `int`, so that when the role is externally managed, the primary key can be set to the unique id of the external role/group.
* the alembic recipe is completely untested
* it might require more changes or more fields in the DB model