### PR TITLE
cli: create user with profile

### DIFF
--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -8,11 +8,11 @@
 
 """Command Line Interface for accounts."""
 
+import json
 from datetime import datetime
 from functools import wraps
 
 import click
-import json
 from flask import current_app
 from flask.cli import with_appcontext
 from flask_security.forms import ConfirmRegisterForm

--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from functools import wraps
 
 import click
+import json
 from flask import current_app
 from flask.cli import with_appcontext
 from flask_security.forms import ConfirmRegisterForm
@@ -48,9 +49,10 @@ def roles():
 @click.password_option()
 @click.option("-a", "--active", default=False, is_flag=True)
 @click.option("-c", "--confirm", default=False, is_flag=True)
+@click.option("-p", "--profile")
 @with_appcontext
 @commit
-def users_create(email, password, active, confirm):
+def users_create(email, password, active, confirm, profile):
     """Create a user."""
     kwargs = dict(email=email, password=password, active="y" if active else "")
 
@@ -61,6 +63,8 @@ def users_create(email, password, active, confirm):
         kwargs["active"] = active
         if confirm:
             kwargs["confirmed_at"] = datetime.utcnow()
+        if profile:
+            kwargs["user_profile"] = json.loads(profile)
         _datastore.create_user(**kwargs)
         click.secho("User created successfully.", fg="green")
         kwargs["password"] = "****"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,23 @@ def test_cli_createuser(app):
     result = runner.invoke(users_create, ["not-an-email", "--password", "123456"])
     assert result.exit_code == 2
 
+    # Create use with profile that is not valid JSON
+    result = runner.invoke(
+        users_create, ["test@example.com", "--profile", "<json>profile</json>"]
+    )
+    assert result.exit_code != 0
+
+    # Create use with profile that will not validate
+    result = runner.invoke(
+        users_create,
+        [
+            "test@example.com",
+            "--profile",
+            '{"full_name" : "test_user", "extra_data" : "not_allowed"}',
+        ],
+    )
+    assert result.exit_code != 0
+
     # Create user
     result = runner.invoke(
         users_create, ["info@inveniosoftware.org", "--password", "123456"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,19 +33,41 @@ def test_cli_createuser(app):
     result = runner.invoke(users_create, ["not-an-email", "--password", "123456"])
     assert result.exit_code == 2
 
-    # Create use with profile that is not valid JSON
-    result = runner.invoke(
-        users_create, ["test@example.com", "--profile", "<json>profile</json>"]
-    )
-    assert result.exit_code != 0
-
-    # Create use with profile that will not validate
+    # Create user with profile
     result = runner.invoke(
         users_create,
         [
-            "test@example.com",
+            "--password",
+            "AValidPassword66!",
+            "--profile",
+            '{"full_name" : "Test User"}',
+            "test1@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Create user with profile that is not valid JSON
+    result = runner.invoke(
+        users_create,
+        [
+            "--password",
+            "AValidPassword66!",
+            "--profile",
+            "<json>profile</json>",
+            "test2@example.com",
+        ],
+    )
+    assert result.exit_code != 0
+
+    # Create user with JSON profile that will not validate
+    result = runner.invoke(
+        users_create,
+        [
+            "--password",
+            "AValidPassword66!",
             "--profile",
             '{"full_name" : "test_user", "extra_data" : "not_allowed"}',
+            "test3@example.com",
         ],
     )
     assert result.exit_code != 0


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Adds -p/--profile option to `invenio users create` to supply a profile at time of user creation. This enables users to be created on the command line with their full name (and/or other profile items set) configured. 

eg `invenio users create -a -c -p '{"full_name" : "Test User"}'  test@example.com`

(Motivation: a user created above is created with enough details set to make the searchable, in the /api/users endpoint, without the need for the user to modify their profile (nb: also requires default profile/email visibility to be set to public in invenio.cfg))

Discussed with @slint.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
