### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 2.1.0 (released 2023-03-01)
+
+- global: replace deprecated babelex imports
+- update invenio-i18n
+
 Version 2.0.2 (released 2022-12-14)
 
 - cli: add `--confirm` flag when creating a user

--- a/invenio_accounts/__init__.py
+++ b/invenio_accounts/__init__.py
@@ -54,7 +54,7 @@ except AttributeError:
 from .ext import InvenioAccounts, InvenioAccountsREST, InvenioAccountsUI
 from .proxies import current_accounts
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_accounts/admin.py
+++ b/invenio_accounts/admin.py
@@ -12,7 +12,6 @@ from flask import current_app, flash
 from flask_admin.actions import action
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.ajax import QueryAjaxModelLoader
-from flask_admin.form.fields import DateTimeField
 from flask_admin.model.fields import AjaxSelectMultipleField
 from flask_security.recoverable import send_reset_password_instructions
 from flask_security.utils import hash_password

--- a/invenio_accounts/admin.py
+++ b/invenio_accounts/admin.py
@@ -10,15 +10,15 @@
 
 from flask import current_app, flash
 from flask_admin.actions import action
-from flask_admin.babel import lazy_gettext
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.ajax import QueryAjaxModelLoader
 from flask_admin.form.fields import DateTimeField
 from flask_admin.model.fields import AjaxSelectMultipleField
-from flask_babelex import gettext as _
 from flask_security.recoverable import send_reset_password_instructions
 from flask_security.utils import hash_password
 from invenio_db import db
+from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext
 from passlib import pwd
 from werkzeug.local import LocalProxy
 from wtforms.fields import BooleanField

--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -12,7 +12,7 @@
 
 from datetime import timedelta
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 
 from .profiles import UserPreferencesSchema, UserProfileSchema
 from .views import login

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -53,8 +53,9 @@ class InvenioAccounts(object):
     @staticmethod
     def monkey_patch_flask_security():
         """Monkey-patch Flask-Security."""
+
         # Disable remember me cookie generation as it does not work with
-        # session activity tracking (a remember me token will bypass revoking
+        # session activity tracking (remember me token will bypass revoking
         # of a session).
         def patch_do_nothing(*args, **kwargs):
             pass

--- a/invenio_accounts/forms.py
+++ b/invenio_accounts/forms.py
@@ -11,9 +11,9 @@
 Currently supported: recaptcha
 """
 from flask import request
-from flask_babelex import gettext as _
 from flask_security.forms import NextFormMixin
 from flask_wtf import FlaskForm, Recaptcha, RecaptchaField
+from invenio_i18n import gettext as _
 from wtforms import FormField, HiddenField
 
 

--- a/invenio_accounts/profiles/schemas.py
+++ b/invenio_accounts/profiles/schemas.py
@@ -9,7 +9,7 @@
 """Schemas for user profiles and preferences."""
 
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from marshmallow import Schema, ValidationError, fields
 
 

--- a/invenio_accounts/tasks.py
+++ b/invenio_accounts/tasks.py
@@ -16,7 +16,6 @@ from flask_mail import Message
 from invenio_db import db
 
 from .models import LoginInformation, SessionActivity
-from .proxies import current_accounts
 from .sessions import delete_session
 
 

--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -14,13 +14,13 @@ from datetime import datetime
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from flask import current_app, request, session, url_for
-from flask_babelex import lazy_gettext as _
 from flask_security import current_user
 from flask_security.confirmable import generate_confirmation_token
 from flask_security.recoverable import generate_reset_password_token
 from flask_security.signals import password_changed, user_registered
 from flask_security.utils import config_value as security_config_value
 from flask_security.utils import get_security_endpoint_name, hash_password, send_mail
+from invenio_i18n import lazy_gettext as _
 from jwt import DecodeError, ExpiredSignatureError, decode, encode
 from werkzeug.routing import BuildError
 from werkzeug.utils import import_string

--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -20,7 +20,6 @@ from flask_security.recoverable import generate_reset_password_token
 from flask_security.signals import password_changed, user_registered
 from flask_security.utils import config_value as security_config_value
 from flask_security.utils import get_security_endpoint_name, hash_password, send_mail
-from invenio_i18n import lazy_gettext as _
 from jwt import DecodeError, ExpiredSignatureError, decode, encode
 from werkzeug.routing import BuildError
 from werkzeug.utils import import_string

--- a/invenio_accounts/views/security.py
+++ b/invenio_accounts/views/security.py
@@ -9,12 +9,12 @@
 """Invenio user management and authentication."""
 
 from flask import abort, current_app, flash, redirect, render_template, request, url_for
-from flask_babelex import lazy_gettext as _
 from flask_breadcrumbs import register_breadcrumb
 from flask_login import login_required
 from flask_menu import register_menu
 from flask_security import current_user
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 from invenio_theme.proxies import current_theme_icons
 from speaklater import make_lazy_string
 

--- a/invenio_accounts/views/settings.py
+++ b/invenio_accounts/views/settings.py
@@ -9,9 +9,9 @@
 """Invenio user management and authentication."""
 
 from flask import Blueprint, current_app
-from flask_babelex import lazy_gettext as _
 from flask_breadcrumbs import register_breadcrumb
 from flask_menu import current_menu
+from invenio_i18n import lazy_gettext as _
 from invenio_theme.proxies import current_theme_icons
 
 blueprint = Blueprint(

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,7 +22,7 @@ trap cleanup EXIT
 
 
 python -m check_manifest
-python -m setup extract_messages --dry-run
+python -m setup extract_messages --output-file /dev/null
 python -m sphinx.cmd.build -qnN docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --cache ${CACHE:-redis} --env)"
 python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,12 @@ zip_safe = False
 install_requires =
     cryptography>=3.0.0
     Flask-KVSession-Invenio>=0.6.3
-    Flask-Security-Invenio>=3.1.3
+    Flask-Security-Invenio>=3.2.0
     invenio-celery>=1.2.3
+    invenio-i18n>=2.0.0
     invenio-mail>=1.0.2
     invenio-rest>=1.2.4
-    invenio-theme>=1.3.4
+    invenio-theme>=2.0.0
     maxminddb-geolite2>=2017.404
     pyjwt>=1.5.0
     simplekv>=0.11.2
@@ -113,7 +114,7 @@ input-file = invenio_accounts/translations/messages.pot
 output-dir = invenio_accounts/translations/
 
 [pydocstyle]
-add_ignore = D401
+add_ignore = D401,D202
 
 [isort]
 profile=black

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,11 @@ import tempfile
 import pytest
 from flask import Flask
 from flask_admin import Admin
-from flask_babelex import Babel
 from flask_celeryext import FlaskCeleryExt
 from flask_mail import Mail
 from flask_menu import Menu
 from invenio_db import InvenioDB, db
-from invenio_i18n import InvenioI18N
+from invenio_i18n import Babel, InvenioI18N
 from invenio_rest import InvenioREST
 from simplekv.memory.redisstore import RedisStore
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,6 @@ def app_with_flexible_registration(request):
     from invenio_accounts.views.rest import RegisterView, use_kwargs
 
     class MyRegisterView(RegisterView):
-
         post_args = {**RegisterView.post_args, "active": fields.Boolean(required=True)}
 
         @use_kwargs(post_args)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,10 +16,10 @@ import time
 
 import pytest
 from flask import Flask
-from flask_babelex import Babel
 from flask_mail import Mail
 from flask_menu import Menu
 from invenio_db import InvenioDB, db
+from invenio_i18n import Babel
 from selenium import webdriver
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -8,13 +8,9 @@
 
 import pytest
 from flask import current_app, session, url_for
-from flask_admin import menu
 from flask_security.utils import hash_password
-from invenio_db import db
 from werkzeug.local import LocalProxy
 
-from invenio_accounts import InvenioAccounts
-from invenio_accounts.cli import users_create
 from invenio_accounts.models import SessionActivity
 from invenio_accounts.testutils import login_user_via_view
 
@@ -37,7 +33,6 @@ def test_admin(app, admin_view):
         inserted_id = _datastore.get_user("test@test.cern").id
 
     with app.test_client() as client:
-
         res = client.post(
             request_url,
             data={"rowid": inserted_id, "action": "activate"},
@@ -140,11 +135,9 @@ def test_admin_sessions(app, admin_view, users):
         assert res.status_code == 200
 
         # simulate login as user 1
-        datastore = app.extensions["security"].datastore
         login_user_via_view(
             client=client, email=users[0]["email"], password=users[0]["password"]
         )
-        from flask import session
 
         sid_s = session.sid_s
         # and try to delete own session sid_s: FAILS
@@ -162,8 +155,10 @@ def test_admin_sessions(app, admin_view, users):
         new_sid_s = session.sid_s
         sessions = SessionActivity.query.all()
         assert len(sessions) == 2
+
         all_sid_s = [session.sid_s for session in sessions]
         assert sorted([sid_s, new_sid_s]) == sorted(all_sid_s)
+
         # and try to delete a session of another user: WORKS
         res = client.post(delete_view_url, data={"id": sid_s}, follow_redirects=True)
         sessions = SessionActivity.query.all()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,6 @@
 
 """Module tests."""
 
-from click.testing import CliRunner
-
 from invenio_accounts.cli import (
     roles_add,
     roles_create,

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -12,10 +12,10 @@
 import pytest
 import requests
 from flask import Flask
-from flask_babelex import Babel
 from flask_mail import Mail
 from flask_security import url_for_security
 from invenio_db import InvenioDB, db
+from invenio_i18n import Babel
 
 from invenio_accounts import InvenioAccounts, InvenioAccountsREST, testutils
 from invenio_accounts.models import Role, User

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,10 +9,9 @@
 """Test account views."""
 
 import base64
-from unittest import mock
 
 from flask import url_for
-from flask_login import COOKIE_NAME, LoginManager
+from flask_login import COOKIE_NAME
 from flask_security import url_for_security
 from flask_security.forms import LoginForm
 from flask_security.views import _security

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,11 +12,11 @@ import base64
 from unittest import mock
 
 from flask import url_for
-from flask_babelex import gettext as _
 from flask_login import COOKIE_NAME, LoginManager
 from flask_security import url_for_security
 from flask_security.forms import LoginForm
 from flask_security.views import _security
+from invenio_i18n import gettext as _
 
 from invenio_accounts.models import SessionActivity
 from invenio_accounts.testutils import create_test_user

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -73,7 +73,6 @@ def _login_user(client, user, email="normal@test.com", password="123456"):
 def test_login_view(api):
     app = api
     with app.app_context():
-
         normal_user = create_test_user(email="normal@test.com")
         create_test_user(email="disabled@test.com", active=False)
         create_test_user(email="nopass@test.com", password=None)
@@ -218,7 +217,6 @@ def test_logout_view(api):
         normal_user = create_test_user(email="normal@test.com")
         db.session.commit()
         with app.test_client() as client:
-
             # Login user
             _login_user(client, normal_user)
             old_session_cookie = next(
@@ -241,7 +239,7 @@ def test_logout_view(api):
 def test_forgot_password_view(api):
     app = api
     with app.app_context():
-        normal_user = create_test_user(email="normal@test.com")
+        create_test_user(email="normal@test.com")
         db.session.commit()
         with app.test_client() as client:
             url = url_for("invenio_accounts_rest_auth.forgot_password")
@@ -265,7 +263,7 @@ def test_disabled_forgot_password_view(api):
 
     with app.app_context():
         user = create_test_user(email="normal@test.com")
-        token = generate_reset_password_token(user)
+        generate_reset_password_token(user)
         db.session.commit()
         with app.test_client() as client:
             url = url_for("invenio_accounts_rest_auth.forgot_password")


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- refactor: remove unused statements

- NOTES:
  - to make this testable it is necessary to release invenio-i18n, flask-security-invenio and invenio-theme
