### PR TITLE
config: ensuring that the setting of ACCOUNTS_REGISTER_BLUEPRINT=Fals…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,37 +7,31 @@ on:
     branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
 
 jobs:
   Tests:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.7, 3.8, 3.9]
-          requirements-level: [min, pypi]
-          cache-service: [redis]
-          db-service: [postgresql14, postgresql13, mysql8]
-          exclude:
-          - python-version: 3.7
-            requirements-level: pypi
-
+        python-version: [3.8, 3.9]
+        requirements-level: [min, pypi]
+        cache-service: [redis]
+        db-service: [postgresql14, postgresql13, mysql8]
+        exclude:
           - python-version: 3.8
             requirements-level: min
 
           - python-version: 3.9
             requirements-level: min
 
-          - db-service: postgresql13
-            python-version: 3.7
-
-          include:
+        include:
           - db-service: postgresql14
             DB_EXTRAS: "postgresql"
 

--- a/invenio_accounts/views/settings.py
+++ b/invenio_accounts/views/settings.py
@@ -52,7 +52,7 @@ def init_menu():
     item = current_menu.submenu("breadcrumbs.settings")
     item.register("invenio_userprofiles.profile", _("Account"))
     if not current_app.config.get("ACCOUNTS_REGISTER_BLUEPRINT"):
-       return
+        return
 
     # - Register menu
     # - Change password

--- a/invenio_accounts/views/settings.py
+++ b/invenio_accounts/views/settings.py
@@ -51,6 +51,8 @@ def init_menu():
     # Register root breadcrumbs
     item = current_menu.submenu("breadcrumbs.settings")
     item.register("invenio_userprofiles.profile", _("Account"))
+    if not current_app.config.get("ACCOUNTS_REGISTER_BLUEPRINT"):
+       return
 
     # - Register menu
     # - Change password

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -101,8 +101,8 @@ def test_init_rest():
     assert "security" not in app.blueprints.keys()
     ext.init_app(app)
     assert "invenio-accounts" in app.extensions
-    assert "security" in app.blueprints.keys()
-    assert "security_email_templates" in app.blueprints.keys()
+    assert "security" not in app.blueprints.keys()
+    assert "security_email_templates" not in app.blueprints.keys()
 
 
 @pytest.mark.skip(reason="Mergepoint is on invenio-access.")

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -91,6 +91,19 @@ def test_init_rest():
     assert "security" in app.blueprints.keys()
     assert "security_email_templates" in app.blueprints.keys()
 
+    app = Flask("testapp")
+    app.config["ACCOUNTS_REGISTER_BLUEPRINT"] = False
+    Babel(app)
+    Mail(app)
+    InvenioDB(app)
+    ext = InvenioAccountsREST()
+    assert "invenio-accounts" not in app.extensions
+    assert "security" not in app.blueprints.keys()
+    ext.init_app(app)
+    assert "invenio-accounts" in app.extensions
+    assert "security" in app.blueprints.keys()
+    assert "security_email_templates" in app.blueprints.keys()
+
 
 @pytest.mark.skip(reason="Mergepoint is on invenio-access.")
 def test_alembic(app):

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -13,12 +13,14 @@ import pytest
 import requests
 from flask import Flask
 from flask_mail import Mail
+from flask_menu import current_menu
 from flask_security import url_for_security
 from invenio_db import InvenioDB, db
 from invenio_i18n import Babel
 
 from invenio_accounts import InvenioAccounts, InvenioAccountsREST, testutils
 from invenio_accounts.models import Role, User
+from invenio_accounts.views.settings import blueprint
 
 
 def test_version():
@@ -104,6 +106,21 @@ def test_init_rest():
     assert "invenio-accounts" in app.extensions
     assert "security" not in app.blueprints.keys()
     assert "security_email_templates" in app.blueprints.keys()
+
+
+def test_accounts_settings_blueprint(base_app):
+    """Test settings blueprint when ACCOUNTS_REGISTER_BLUEPRINT is False."""
+    app = base_app
+    app.config["ACCOUNTS_REGISTER_BLUEPRINT"] = False
+    InvenioAccounts(app)
+    # register settings blueprint
+    app.register_blueprint(blueprint)
+
+    with app.app_context():
+        with app.test_client() as client:
+            client.get("/account/settings")
+            menu = current_menu.submenu("settings.change_password", auto_create=False)
+            assert not menu
 
 
 @pytest.mark.skip(reason="Mergepoint is on invenio-access.")

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -92,6 +92,7 @@ def test_init_rest():
     assert "security_email_templates" in app.blueprints.keys()
 
     app = Flask("testapp")
+    app.config["SECRET_KEY"] = "CHANGEME"
     app.config["ACCOUNTS_REGISTER_BLUEPRINT"] = False
     Babel(app)
     Mail(app)
@@ -102,7 +103,7 @@ def test_init_rest():
     ext.init_app(app)
     assert "invenio-accounts" in app.extensions
     assert "security" not in app.blueprints.keys()
-    assert "security_email_templates" not in app.blueprints.keys()
+    assert "security_email_templates" in app.blueprints.keys()
 
 
 @pytest.mark.skip(reason="Mergepoint is on invenio-access.")


### PR DESCRIPTION
…e works

:heart: Thank you for your contribution!

### Description

Setting the parameter of `ACCOUNTS_REGISTER_BLUEPRINT=False` on opendata gave the following error:

```
172.19.0.1 - - [20/Dec/2023 09:02:07] "GET / HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/opt/invenio/var/instance/python/lib/python3.9/site-packages/flask/app.py", line 2552, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/invenio/var/instance/python/lib/python3.9/site-packages/werkzeug/middleware/dispatcher.py", line 78, in __call__
    return app(environ, start_response)
  File "/opt/invenio/var/instance/python/lib/python3.9/site-packages/flask/app.py", line 2532, in wsgi_app
    response = self.handle_exception(e)
  File "/opt/invenio/var/instance/python/lib/python3.9/site-packages/flask/app.py", line 2529, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/invenio/var/instance/python/lib/python3.9/site-packages/flask/app.py", line 1815, in full_dispatch_request
    self.ensure_sync(func)()
  File "/opt/invenio/var/instance/python/lib/python3.9/site-packages/invenio_accounts/views/settings.py", line 83, in init_menu
    current_app.view_functions[view_name]
KeyError: 'security.change_password'
```

It looks like the initialization is sill requiring some settings that should not be needed. 
This patch addresses that issue.

