### PR TITLE
Fix Domain.status column type and release v4.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 4.0.1 (released 2024-02-01)
+
+- models: fix column type for domain status
+
 Version 4.0.0 (released 2024-01-29)
 
 - sessions: check for request before accessing session

--- a/invenio_accounts/__init__.py
+++ b/invenio_accounts/__init__.py
@@ -54,7 +54,7 @@ except AttributeError:
 from .ext import InvenioAccounts, InvenioAccountsREST, InvenioAccountsUI
 from .proxies import current_accounts
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 __all__ = (
     "__version__",

--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy_utils import IPAddressType, Timestamp
-from sqlalchemy_utils.types import JSONType
+from sqlalchemy_utils.types import ChoiceType, JSONType
 
 from .errors import AlreadyLinkedError
 from .profiles import UserPreferenceDict, UserProfileDict
@@ -545,7 +545,11 @@ class Domain(db.Model, Timestamp):
     tld = db.Column(db.String(255), nullable=False)
     """Top-level domain."""
 
-    status = db.Column(db.Enum(DomainStatus), default=DomainStatus.new, nullable=False)
+    status = db.Column(
+        ChoiceType(DomainStatus, impl=db.Integer()),
+        default=DomainStatus.new,
+        nullable=False,
+    )
     """Status of domain.
 
     Use to control possibility and capability of users registering with this domain.


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/652

- models: fix column type for domain status
- release: v4.0.1
