### PR TITLE
Models: fix username case-insensitive comparator & release: v5.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 5.0.1 (released 2024-03-22)
+
+- models: fix username case-insensitive comparator
+
 Version 5.0.0 (released 2024-03-21)
 
 - fix: before_first_request deprecation

--- a/invenio_accounts/__init__.py
+++ b/invenio_accounts/__init__.py
@@ -54,7 +54,7 @@ except AttributeError:
 from .ext import InvenioAccounts, InvenioAccountsREST, InvenioAccountsUI
 from .proxies import current_accounts
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 __all__ = (
     "__version__",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -152,6 +152,16 @@ def test_user_domain_attr(app):
     assert u.domain == "cern.ch"
 
 
+def test_user_username_case_insensitive_comparator(app):
+    ds = app.extensions["invenio-accounts"].datastore
+    ds.create_user(username="UserName")
+    ds.commit()
+
+    u = ds.find_user(username="uSERnAME")
+    assert u is not None
+    assert u.username == "UserName"
+
+
 def test_domain_model(app):
     d = Domain.create("CERN.CH")
     assert d.domain == "cern.ch"


### PR DESCRIPTION
Fixes https://github.com/zenodo/ops/issues/326

:heart: Thank you for your contribution!

### Description

Usernames are enforced to be unique in the DB regardless of their case ([see related DB column and constraint definition](https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/alembic/eb9743315a9d_add_userprofile.py#L53-L66)).

This change proposes to compare usernames case-insensitively.
This will avoid problems like users trying to sign up with an existing username but with a different case, which are currently hitting the DB constraint and then showing an nginx 502 error since it is not well handled by Flask.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
