### PR TITLE
Domains:  Add uniqueness constraint and tests for DomainCategory model and CLI

### DIFF
--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2023 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -170,8 +171,14 @@ def users_deactivate(user):
 @with_appcontext
 def domains_create(domain):
     """Create domain."""
+    domain = domain.lower()
+
+    if DomainCategory.get(domain):
+        click.secho(f"Domain {domain} already exists.", fg="red")
+        return
+
     try:
-        domain_category = DomainCategory.create(domain.lower())
+        domain_category = DomainCategory.create(domain)
         db.session.merge(domain_category)
         db.session.commit()
     except Exception as error:

--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2022 KTH Royal Institute of Technology
+# Copyright (C) 2022-2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -526,7 +526,7 @@ class DomainCategory(db.Model):
 
     id = db.Column(db.Integer(), primary_key=True, autoincrement=True)
 
-    label = db.Column(db.String(255))
+    label = db.Column(db.String(255), unique=True)
 
     @classmethod
     def create(cls, label):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,6 +11,7 @@
 """Module tests."""
 
 from invenio_accounts.cli import (
+    domains_create,
     roles_add,
     roles_create,
     roles_remove,
@@ -156,3 +158,28 @@ def test_cli_activate_deactivate(app):
     assert result.exit_code == 0
     result = runner.invoke(users_deactivate, ["a@test.org"])
     assert result.exit_code == 0
+
+
+def test_cli_createdomain(app):
+    """Test create domain CLI."""
+    runner = app.test_cli_runner()
+
+    # Create a domain successfully
+    result = runner.invoke(domains_create, ["mailprovider"])
+    assert result.exit_code == 0
+    assert "Domain mailprovider created successfully" in result.output
+
+    # Reject Creating the same domain again
+    result = runner.invoke(domains_create, ["mailprovider"])
+    assert result.exit_code == 0
+    assert "Domain mailprovider already exists." in result.output
+
+    # Create another domain successfully
+    result = runner.invoke(domains_create, ["kth.se"])
+    assert result.exit_code == 0
+    assert "Domain kth.se created successfully" in result.output
+
+    # Create a domain with a fancy case should be treated like others
+    result = runner.invoke(domains_create, ["MailPrOvIdEr"])
+    assert result.exit_code == 0
+    assert "Domain mailprovider already exists." in result.output


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Added `unique=True` constraint to the `label` field in `DomainCategory` model to enforce uniqueness at the database level.
* Modified `domains_create` CLI command to check for duplicates before creating a new domain category, providing feedback if the domain already exists.
* Added tests for `DomainCategory` model to validate creation, retrieval, and handling of duplicate labels.
* Enhanced `test_cli_createdomain`
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2796



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
