### PR TITLE
security: filter out master_session if it's set to `None`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 5.1.2 (released 2024-09-19)
+
+- setup: bump minimum flask-security-invenio dependency
+- security: handle missing value for current session
+
 Version 5.1.1 (released 2024-08-08)
 
 - revert: commit f9a8a85

--- a/invenio_accounts/__init__.py
+++ b/invenio_accounts/__init__.py
@@ -55,7 +55,7 @@ except AttributeError:
 from .ext import InvenioAccounts, InvenioAccountsREST, InvenioAccountsUI
 from .proxies import current_accounts
 
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 
 __all__ = (
     "__version__",

--- a/invenio_accounts/views/security.py
+++ b/invenio_accounts/views/security.py
@@ -22,15 +22,19 @@ from ..sessions import delete_session
 def security():
     """View for security page."""
     sessions = SessionActivity.query_by_user(user_id=current_user.get_id()).all()
-    master_session = None
+    current_session = None
     for index, session in enumerate(sessions):
         if SessionActivity.is_current(session.sid_s):
-            master_session = session
+            current_session = session
             del sessions[index]
+
+    # If the current session is still `None`, filter it out
+    sessions = [current_session] + sessions if current_session is not None else sessions
+
     return render_template(
         current_app.config["ACCOUNTS_SETTINGS_SECURITY_TEMPLATE"],
         formclass=RevokeForm,
-        sessions=[master_session] + sessions,
+        sessions=sessions,
         is_current=SessionActivity.is_current,
     )
 


### PR DESCRIPTION
Closes #491 

The resulting security page when impersonating users:
![image](https://github.com/user-attachments/assets/48f09891-8224-4810-bac3-152f36e72f95)

It may look a little strange, but i consider that better than a 500 internal server error :smile: 