### PR TITLE
fix: translation only applied on app start

### DIFF
--- a/invenio_accounts/admin.py
+++ b/invenio_accounts/admin.py
@@ -17,8 +17,7 @@ from flask_admin.model.fields import AjaxSelectMultipleField
 from flask_security.recoverable import send_reset_password_instructions
 from flask_security.utils import hash_password
 from invenio_db import db
-from invenio_i18n import gettext as _
-from invenio_i18n import lazy_gettext
+from invenio_i18n import lazy_gettext as _
 from passlib import pwd
 from werkzeug.local import LocalProxy
 from wtforms.fields import BooleanField
@@ -182,8 +181,8 @@ class SessionActivityView(ModelView):
 
     @action(
         "delete",
-        lazy_gettext("Delete selected sessions"),
-        lazy_gettext("Are you sure you want to delete selected sessions?"),
+        _("Delete selected sessions"),
+        _("Are you sure you want to delete selected sessions?"),
     )
     def action_delete(self, ids):
         """Delete selected sessions."""

--- a/invenio_accounts/forms.py
+++ b/invenio_accounts/forms.py
@@ -14,7 +14,7 @@ from flask import request
 from flask_security.forms import NextFormMixin
 from flask_wtf import FlaskForm, Recaptcha, RecaptchaField
 from invenio_db import db
-from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext as _
 from wtforms import FormField, HiddenField
 
 from .proxies import current_datastore


### PR DESCRIPTION
### Description

This pull request fixes premature evaluation of i18n strings inside static fields. gettext call, that causes
the evaluation to be performed at boot time, was replaced with gettext_lazy that is performed at
request time. This fixes admin actions and validation error not being translated when language is changed.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
