### PR TITLE
fix: Catch ValueError exception celery is not defined

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -222,9 +222,12 @@ class InvenioAccounts(object):
 
         :param app: The Flask application.
         """
-        if find_spec("celery") is not None:
-            app.config.setdefault("ACCOUNTS_USE_CELERY", not (app.debug or app.testing))
-        else:
+        try:
+            if find_spec("celery") is not None:
+                app.config.setdefault(
+                    "ACCOUNTS_USE_CELERY", not (app.debug or app.testing)
+                )
+        except ValueError:
             app.config.setdefault("ACCOUNTS_USE_CELERY", False)
 
         # Register Invenio legacy password hashing


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Without catching that exception, I was getting:

```
[2025-07-03 13:25:47,426] ERROR in app: Failed to initialize entry point: EntryPoint(name='invenio_accounts_ui', value='invenio_accounts:InvenioAccountsUI', group='invenio_base.apps')
Traceback (most recent call last):
  File "/usr/local/bin/cernopendata", line 33, in <module>
    sys.exit(load_entry_point('cernopendata', 'console_scripts', 'cernopendata')())
  File "/root/.local/lib/python3.9/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/root/.local/lib/python3.9/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/root/.local/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/.local/lib/python3.9/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/.local/lib/python3.9/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/root/.local/lib/python3.9/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/root/.local/lib/python3.9/site-packages/flask/cli.py", line 397, in decorator
    app = ctx.ensure_object(ScriptInfo).load_app()
  File "/root/.local/lib/python3.9/site-packages/flask/cli.py", line 342, in load_app
    app = self.create_app()
  File "/root/.local/lib/python3.9/site-packages/invenio_base/app.py", line 197, in create_cli_app
    app = create_app(debug=get_debug_flag())
  File "/root/.local/lib/python3.9/site-packages/invenio_base/app.py", line 127, in _create_app
    app_loader(
  File "/root/.local/lib/python3.9/site-packages/invenio_base/app.py", line 235, in app_loader
    _loader(app, lambda ext: ext(app), entry_points=entry_points, modules=modules)
  File "/root/.local/lib/python3.9/site-packages/invenio_base/app.py", line 306, in _loader
    init_func(ep.load())
  File "/root/.local/lib/python3.9/site-packages/invenio_base/app.py", line 235, in <lambda>
    _loader(app, lambda ext: ext(app), entry_points=entry_points, modules=modules)
  File "/usr/local/lib/python3.9/site-packages/invenio_accounts/ext.py", line 57, in __init__
    self.init_app(app, sessionstore=sessionstore)
  File "/usr/local/lib/python3.9/site-packages/invenio_accounts/ext.py", line 321, in init_app
    return super(InvenioAccountsUI, self).init_app(
  File "/usr/local/lib/python3.9/site-packages/invenio_accounts/ext.py", line 138, in init_app
    self.init_config(app)
  File "/usr/local/lib/python3.9/site-packages/invenio_accounts/ext.py", line 225, in init_config
    if find_spec("celery") is not None:
  File "/usr/lib64/python3.9/importlib/util.py", line 114, in find_spec
    raise ValueError('{}.__spec__ is None'.format(name))
ValueError: celery.__spec__ is None

```
Downgrading to 6.0.1 (or this patch) fixes the issue

