### PR TITLE
cli: don't allow role changes on externally managed

### DIFF
--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -112,7 +112,14 @@ def roles_add(user, role):
         raise click.UsageError("Cannot find user.")
     if role is None:
         raise click.UsageError("Cannot find role.")
-
+    if not role.is_managed:
+        click.secho(
+            'Role "{0}" is externally managed. Cannot perform CLI actions on it.'.format(
+                role
+            ),
+            fg="red",
+        )
+        return
     if _datastore.add_role_to_user(user, role):
         click.secho(
             f"Role '{role}' added to user '{user}' successfully.",
@@ -134,6 +141,14 @@ def roles_remove(user, role):
         raise click.UsageError("Cannot find user.")
     if role is None:
         raise click.UsageError("Cannot find role.")
+    if not role.is_managed:
+        click.secho(
+            'Role "{0}" is externally managed. Cannot perform CLI actions on it.'.format(
+                role
+            ),
+            fg="red",
+        )
+        return
     if _datastore.remove_role_from_user(user, role):
         click.secho(
             'Role "{0}" removed from user "{1}" ' "successfully.".format(role, user),


### PR DESCRIPTION
- as per issue https://github.com/inveniosoftware/invenio-accounts/issues/445, added new condition in role related CLI operations to restrict the possibility of membership change on externally managed groups.


