### PR TITLE
fix: Failing invenio-admin due to lazy string

### DIFF
--- a/invenio_accounts/admin.py
+++ b/invenio_accounts/admin.py
@@ -159,11 +159,15 @@ class SessionActivityView(ModelView):
 
     list_all = ("user.id", "user.email", "sid_s", "created")
 
-    column_labels = {
-        "user.id": lazy_gettext("User ID"),
-        "user.email": lazy_gettext("Email"),
-        "sid_s": lazy_gettext("Session ID"),
-    }
+    @property
+    def column_labels(self):
+        """Return translated column labels."""
+        return {
+            "user.id": _("User ID"),
+            "user.email": _("Email"),
+            "sid_s": _("Session ID"),
+        }
+
     column_list = list_all
     column_filters = list_all
     column_sortable_list = list_all
@@ -218,10 +222,13 @@ class UserIdentityView(ModelView):
         "user.email",
     )
 
-    column_labels = {
-        "user.email": lazy_gettext("Email"),
-        "id_user": lazy_gettext("User ID"),
-    }
+    @property
+    def column_labels(self):
+        """Return translated column labels."""
+        return {
+            "user.email": _("Email"),
+            "id_user": _("User ID"),
+        }
 
 
 session_adminview = {


### PR DESCRIPTION
### Description

Lazy strings are not handled correctly in `column_labels` part of flask-admin's `ModelAdmin` class (and seem to be ok elsewhere). This PR fixes that by converting column_labels to computed properties and performing simple gettext there.

This bug was reported in https://github.com/inveniosoftware/invenio-accounts/issues/529

After the fix the UI looks like:

<img width="625" height="419" alt="image" src="https://github.com/user-attachments/assets/61438a70-f481-45a1-8eb6-e1da77d67f51" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
