### PR TITLE
feat: adapt for pluggable password validation

### DIFF
--- a/invenio_accounts/views/rest.py
+++ b/invenio_accounts/views/rest.py
@@ -218,6 +218,12 @@ def validate_domain_rest(email):
         raise ValidationError(_("The email domain is blocked."))
 
 
+def validate_password(password):
+    """Validate password using Flask-Security."""
+    if msg := current_security._password_validator(password, True):
+        raise ValidationError(msg)
+
+
 def _abort(message, field=None, status=None):
     if field:
         raise RESTValidationError([FieldError(field, message)])
@@ -324,9 +330,7 @@ class RegisterView(MethodView):
         "email": fields.Email(
             required=True, validate=[unique_user_email, validate_domain_rest]
         ),
-        "password": fields.String(
-            required=True, validate=[validate.Length(min=6, max=128)]
-        ),
+        "password": fields.String(required=True, validate=[validate_password]),
     }
 
     def login_user(self, user):
@@ -404,9 +408,7 @@ class ResetPasswordView(MethodView):
 
     post_args = {
         "token": fields.String(required=True),
-        "password": fields.String(
-            required=True, validate=[validate.Length(min=6, max=128)]
-        ),
+        "password": fields.String(required=True, validate=[validate_password]),
     }
 
     def get_user(self, token=None, **kwargs):
@@ -449,12 +451,8 @@ class ChangePasswordView(MethodView):
     decorators = [login_required]
 
     post_args = {
-        "password": fields.String(
-            required=True, validate=[validate.Length(min=6, max=128)]
-        ),
-        "new_password": fields.String(
-            required=True, validate=[validate.Length(min=6, max=128)]
-        ),
+        "password": fields.String(required=True, validate=[validate_password]),
+        "new_password": fields.String(required=True, validate=[validate_password]),
     }
 
     def verify_password(self, password=None, new_password=None, **kwargs):

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -171,7 +171,7 @@ def test_registration_view(api):
             assert_error_resp(
                 res,
                 (
-                    ("password", "length"),
+                    ("password", "password must be at least"),
                     ("email", "not a valid email"),
                 ),
             )


### PR DESCRIPTION
* Adapts password validation to use Flask-Security-Invenio's pluggable password validation.

* NOTE: the default password validation is backwards compatible, meaning that it only checks for a minimum length of 6.

Requires https://github.com/inveniosoftware/flask-security-fork/pull/79