### PR TITLE
fix(chore): DeprecationWarning stdlib

### DIFF
--- a/invenio_accounts/admin.py
+++ b/invenio_accounts/admin.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2025 CERN.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,6 +17,7 @@ from flask_admin.contrib.sqla.ajax import QueryAjaxModelLoader
 from flask_admin.model.fields import AjaxSelectMultipleField
 from flask_security.recoverable import send_reset_password_instructions
 from flask_security.utils import hash_password
+from invenio_admin.filters import FilterConverter
 from invenio_db import db
 from invenio_i18n import gettext as _
 from invenio_i18n import lazy_gettext
@@ -34,6 +36,7 @@ _datastore = LocalProxy(lambda: current_app.extensions["security"].datastore)
 class UserView(ModelView):
     """Flask-Admin view to manage users."""
 
+    filter_converter = FilterConverter()
     can_view_details = True
     can_delete = False
 
@@ -127,6 +130,8 @@ class UserView(ModelView):
 class RoleView(ModelView):
     """Admin view for roles."""
 
+    filter_converter = FilterConverter()
+
     can_view_details = True
 
     list_all = ("id", "name", "description")
@@ -152,6 +157,8 @@ class RoleView(ModelView):
 
 class SessionActivityView(ModelView):
     """Admin view for user sessions."""
+
+    filter_converter = FilterConverter()
 
     can_view_details = False
     can_create = False
@@ -198,6 +205,8 @@ class SessionActivityView(ModelView):
 
 class UserIdentityView(ModelView):
     """Flask-Admin view to manage user identities from invenio-accounts."""
+
+    filter_converter = FilterConverter()
 
     can_view_details = True
     can_create = False

--- a/invenio_accounts/cli.py
+++ b/invenio_accounts/cli.py
@@ -10,7 +10,7 @@
 """Command Line Interface for accounts."""
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 
 import click
@@ -71,7 +71,7 @@ def users_create(email, password, active, confirm, profile):
         kwargs["password"] = hash_password(kwargs["password"])
         kwargs["active"] = active
         if confirm:
-            kwargs["confirmed_at"] = datetime.utcnow()
+            kwargs["confirmed_at"] = datetime.now(timezone.utc)
         if profile:
             kwargs["user_profile"] = json.loads(profile)
         _datastore.create_user(**kwargs)

--- a/invenio_accounts/datastore.py
+++ b/invenio_accounts/datastore.py
@@ -2,14 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Session-aware datastore."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app
 from flask_security import SQLAlchemyUserDatastore, user_confirmed
@@ -28,7 +28,7 @@ class SessionAwareSQLAlchemyUserDatastore(SQLAlchemyUserDatastore):
 
     def verify_user(self, user):
         """Verify a user."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         user.blocked_at = None
         user.verified_at = now
         user.active = True
@@ -38,7 +38,7 @@ class SessionAwareSQLAlchemyUserDatastore(SQLAlchemyUserDatastore):
 
     def block_user(self, user):
         """Verify a user."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         user.blocked_at = now
         user.verified_at = None
         user.active = False
@@ -50,7 +50,7 @@ class SessionAwareSQLAlchemyUserDatastore(SQLAlchemyUserDatastore):
         res = super().activate_user(user)
         user.blocked_at = None
         if user.confirmed_at is None:
-            user.confirmed_at = datetime.utcnow()
+            user.confirmed_at = datetime.now(timezone.utc)
             user_confirmed.send(current_app._get_current_object(), user=user)
         return res
 

--- a/invenio_accounts/models.py
+++ b/invenio_accounts/models.py
@@ -3,7 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
 # Copyright (C) 2022 KTH Royal Institute of Technology
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +12,7 @@
 
 import inspect
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app, session
 from flask_babel import refresh
@@ -23,7 +23,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 from sqlalchemy.orm import validates
-from sqlalchemy_utils import IPAddressType, Timestamp
+from sqlalchemy_utils import IPAddressType
 from sqlalchemy_utils.types import ChoiceType, JSONType
 
 from .errors import AlreadyLinkedError
@@ -71,7 +71,7 @@ class CaseInsensitiveComparator(Comparator):
         return func.lower(self.__clause_element__()) == func.lower(other)
 
 
-class Role(db.Model, Timestamp, RoleMixin):
+class Role(db.Model, db.Timestamp, RoleMixin):
     """Role data model."""
 
     __tablename__ = "accounts_role"
@@ -98,7 +98,7 @@ class Role(db.Model, Timestamp, RoleMixin):
         return "{0.name} - {0.description}".format(self)
 
 
-class User(db.Model, Timestamp, UserMixin):
+class User(db.Model, db.Timestamp, UserMixin):
     """User data model."""
 
     __tablename__ = "accounts_user"
@@ -170,7 +170,7 @@ class User(db.Model, Timestamp, UserMixin):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         self.verified_at = (
-            datetime.utcnow()
+            datetime.now(timezone.utc)
             if current_app.config.get("ACCOUNTS_DEFAULT_USERS_VERIFIED")
             else None
         )
@@ -383,7 +383,7 @@ class LoginInformation(db.Model):
         return value
 
 
-class SessionActivity(db.Model, Timestamp):
+class SessionActivity(db.Model, db.Timestamp):
     """User Session Activity model.
 
     Instances of this model correspond to a session belonging to a user.
@@ -426,7 +426,7 @@ class SessionActivity(db.Model, Timestamp):
     def query_by_expired(cls):
         """Query to select all expired sessions."""
         lifetime = current_app.permanent_session_lifetime
-        expired_moment = datetime.utcnow() - lifetime
+        expired_moment = datetime.now(timezone.utc) - lifetime
         return db.session.query(cls).filter(cls.created < expired_moment)
 
     @classmethod
@@ -440,7 +440,7 @@ class SessionActivity(db.Model, Timestamp):
         return session.sid_s == sid_s
 
 
-class UserIdentity(db.Model, Timestamp):
+class UserIdentity(db.Model, db.Timestamp):
     """Represent a UserIdentity record."""
 
     __tablename__ = "accounts_useridentity"
@@ -555,7 +555,7 @@ class DomainCategory(db.Model):
         return db.session.query(cls).filter_by(label=label).one_or_none()
 
 
-class Domain(db.Model, Timestamp):
+class Domain(db.Model, db.Timestamp):
     """User domains model."""
 
     __tablename__ = "accounts_domains"

--- a/invenio_accounts/tasks.py
+++ b/invenio_accounts/tasks.py
@@ -2,14 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2025 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Background tasks for accounts."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from celery import shared_task
 from flask import current_app
@@ -65,7 +65,7 @@ def clean_session_table():
 def delete_ips():
     """Automatically remove login_info.last_login_ip older than 30 days."""
     expiration_date = (
-        datetime.utcnow() - current_app.config["ACCOUNTS_RETENTION_PERIOD"]
+        datetime.now(timezone.utc) - current_app.config["ACCOUNTS_RETENTION_PERIOD"]
     )
 
     db.session.query(LoginInformation).filter(
@@ -130,7 +130,7 @@ def update_domain_status():
 
     # Commit batches of 500 updates
     batch_size = 500
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # Process updates in batches
     for i in range(0, len(domain_updates), batch_size):

--- a/invenio_accounts/utils.py
+++ b/invenio_accounts/utils.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2024 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +12,7 @@
 import enum
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from flask import current_app, request, session, url_for
@@ -70,7 +70,7 @@ def jwt_create_token(user_id=None, additional_data=None):
     # Create an ID
     uid = str(uuid.uuid4())
     # The time in UTC now
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     # Build the token data
     token_data = {
         "exp": now + current_app.config["ACCOUNTS_JWT_EXPIRATION_DELTA"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -231,7 +231,7 @@ def api(request):
 @pytest.fixture()
 def app_with_redis_url(request):
     """Flask application fixture with Invenio Accounts."""
-    app = _app_factory(dict(ACCOUNTS_SESSION_REDIS_URL="redis://localhost:6379/0"))
+    app = _app_factory(dict(ACCOUNTS_SESSION_REDIS_URL="redis://localhost:6380/0"))
     app.config.update(ACCOUNTS_USERINFO_HEADERS=True)
     InvenioAccounts(app)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +10,7 @@
 
 """Module tests."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import sleep
 
 from flask import url_for
@@ -115,11 +115,11 @@ def test_clean_session_table(task_app):
 def test_delete_ips(task_app):
     """Test if ips are deleted after 30 days."""
     last_login_at1 = (
-        datetime.utcnow()
+        datetime.now(timezone.utc)
         - task_app.config["ACCOUNTS_RETENTION_PERIOD"]
         - timedelta(days=1)
     )
-    last_login_at2 = datetime.utcnow()
+    last_login_at2 = datetime.now(timezone.utc)
 
     with task_app.app_context():
         user1 = create_test_user(


### PR DESCRIPTION
* datetime.datetime.utcnow() is deprecated and scheduled for removal in
  a future version. Use timezone-aware objects to represent datetimes in
  UTC: datetime.datetime.now(datetime.UTC).

* the decision was made to move to utc aware timestamps

* the FilterConverter addition is necessary to make the flask-admin
  work, because flask-admin doesn't know anything about the UTCDateTime
  column type
