### PR TITLE
chore: compatibility webargs > 6.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v7.1.0 (released 2026-03-12)
+
+- chore: compatibility webargs > 6.0.0
+- chore: remove usage of python2 compat
+
 Version v7.0.0 (released 2026-01-27)
 
 - chore(setup): bump dependencies

--- a/invenio_accounts/__init__.py
+++ b/invenio_accounts/__init__.py
@@ -56,7 +56,7 @@ except AttributeError:
 from .ext import InvenioAccounts, InvenioAccountsREST, InvenioAccountsUI
 from .proxies import current_accounts
 
-__version__ = "7.0.0"
+__version__ = "7.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_accounts/hash.py
+++ b/invenio_accounts/hash.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +13,6 @@ import hashlib
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from passlib.utils.compat import str_to_uascii
 from passlib.utils.handlers import GenericHandler, HasSalt, parse_mc2, render_mc2
 
 __all__ = ("InvenioAesEncryptedEmail",)
@@ -126,6 +126,4 @@ class InvenioAesEncryptedEmail(HasSalt, GenericHandler):
         :param secret: The secret key.
         :returns: The checksum.
         """
-        return str_to_uascii(
-            hashlib.sha256(mysql_aes_encrypt(self.salt, secret)).hexdigest()
-        )
+        return hashlib.sha256(mysql_aes_encrypt(self.salt, secret)).hexdigest()

--- a/invenio_accounts/views/rest.py
+++ b/invenio_accounts/views/rest.py
@@ -3,7 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2017-2024 CERN.
 # Copyright (C)      2021 TU Wien.
-# Copyright (C) 2025 Graz University of Technology.
+# Copyright (C) 2025-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -168,13 +168,26 @@ class FlaskParser(FlaskParserBase):
         """Handle errors during parsing."""
         if isinstance(error, ValidationError):
             _errors = []
-            for field, messages in error.messages.items():
-                _errors.extend([FieldError(field, msg) for msg in messages])
+            try:
+                # webargs >=6.0.0b7
+                for location, field_data in error.messages.items():
+                    for field, messages in field_data.items():
+                        _errors.extend([FieldError(field, msg) for msg in messages])
+            except AttributeError:
+                # webargs < 6.0.0b7
+                for field, messages in error.messages.items():
+                    _errors.extend([FieldError(field, msg) for msg in messages])
             raise RESTValidationError(errors=_errors)
         super(FlaskParser, self).handle_error(error, *args, **kwargs)
 
 
-webargs_parser = FlaskParser()
+try:
+    # webargs >= 6.0.0
+    webargs_parser = FlaskParser(location="form")
+except TypeError:
+    # webargs < 6.0.0
+    webargs_parser = FlaskParser()
+
 use_args = webargs_parser.use_args
 use_kwargs = webargs_parser.use_kwargs
 
@@ -343,15 +356,19 @@ class RegisterView(MethodView):
         """Return a successful register response."""
         return jsonify(default_user_payload(user))
 
-    @use_kwargs(post_args)
-    def post(self, **kwargs):
-        """Register a user."""
+    def _post(self, **kwargs):
+        """To call it from inherited classes."""
         if not current_security.registerable:
             _abort(get_message("REGISTRATION_DISABLED")[0])
 
         user = register_user(**kwargs)
         self.login_user(user)
         return self.success_response(user)
+
+    @use_kwargs(post_args)
+    def post(self, **kwargs):
+        """Register a user."""
+        return self._post(**kwargs)
 
 
 class ForgotPasswordView(MethodView, UserViewMixin):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,7 @@ def app_with_flexible_registration(request):
         @use_kwargs(post_args)
         def post(self, **kwargs):
             """Register a user."""
-            return super(MyRegisterView, self).post(**kwargs)
+            return self._post(**kwargs)
 
     api_app = _app_factory()
     InvenioREST(api_app)


### PR DESCRIPTION
replacing passlib with libpass is straight forward, only replace passlib with libpass in `flask-security-fork`setup.cfg file. the from passlib statments can stay as they are!!!!

https://github.com/inveniosoftware/flask-security-fork/pull/91 needed for passlib -> libpass

the wip commit has to be removed, it is only there to show that the tests are working with this change