### PR TITLE
feat(auth): add per-account auth rate limits

### DIFF
--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -88,6 +88,48 @@ This will be used to build an absolute URL, thus if e.g. a hostname isn't
 included, the one from the current request's context will be used.
 """
 
+ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT = None
+"""Flask-Limiter rate limit string for forgot-password requests per account.
+
+Example: ``"3 per hour"``. Disabled when ``None``.
+"""
+
+ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT_KEY_PREFIX = "accounts.fp_email"
+"""Prefix used to namespace forgot-password per-account limiter keys."""
+
+ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT_MSG = _(
+    "Too many password-reset requests for this account. Please try again later."
+)
+"""Message shown when forgot-password per-account rate limit is exceeded."""
+
+ACCOUNTS_LOGIN_RATELIMIT = None
+"""Flask-Limiter rate limit string for login requests per account.
+
+Example: ``"5 per 15 minutes"``. Disabled when ``None``.
+"""
+
+ACCOUNTS_LOGIN_RATELIMIT_KEY_PREFIX = "accounts.login"
+"""Prefix used to namespace login per-account limiter keys."""
+
+ACCOUNTS_LOGIN_RATELIMIT_MSG = _(
+    "Too many login attempts for this account. Please try again later."
+)
+"""Message shown when login per-account rate limit is exceeded."""
+
+ACCOUNTS_SEND_CONFIRMATION_RATELIMIT = None
+"""Flask-Limiter rate limit string for send-confirmation requests per account.
+
+Example: ``"3 per hour"``. Disabled when ``None``.
+"""
+
+ACCOUNTS_SEND_CONFIRMATION_RATELIMIT_KEY_PREFIX = "accounts.cf_email"
+"""Prefix used to namespace send-confirmation per-account limiter keys."""
+
+ACCOUNTS_SEND_CONFIRMATION_RATELIMIT_MSG = _(
+    "Too many confirmation-email requests for this account. Please try again later."
+)
+"""Message shown when send-confirmation per-account rate limit is exceeded."""
+
 ACCOUNTS_REST_AUTH_VIEWS = {
     "login": "invenio_accounts.views.rest:LoginView",
     "logout": "invenio_accounts.views.rest:LogoutView",

--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -28,6 +28,7 @@ from werkzeug.utils import cached_property
 
 from invenio_accounts.forms import (
     confirm_register_form_factory,
+    forgot_password_form_factory,
     login_form_factory,
     register_form_factory,
     send_confirmation_form_factory,
@@ -179,6 +180,14 @@ class InvenioAccounts(object):
         app.extensions["security"].login_form = login_form_factory(
             app.extensions["security"].login_form, app
         )
+
+        if app.config.get("ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT"):
+            app.extensions["security"].forgot_password_form = (
+                forgot_password_form_factory(
+                    app.extensions["security"].forgot_password_form,
+                    app,
+                )
+            )
 
         # send confirmation form
         app.extensions["security"].send_confirmation_form = (

--- a/invenio_accounts/forms.py
+++ b/invenio_accounts/forms.py
@@ -18,6 +18,11 @@ from invenio_db import db
 from invenio_i18n import gettext as _
 from wtforms import FormField, HiddenField
 
+from .limiter import (
+    enforce_forgot_password_limit,
+    enforce_login_limit,
+    enforce_send_confirmation_limit,
+)
 from .proxies import current_datastore
 from .utils import validate_domain
 
@@ -86,7 +91,16 @@ def login_form_factory(Form, app):
     """Return extended login form."""
 
     class LoginForm(Form):
-        pass
+        def validate(self, extra_validators=None):
+            is_valid = super().validate(extra_validators=extra_validators)
+            if app.config.get("ACCOUNTS_LOGIN_RATELIMIT"):
+                allowed, message = enforce_login_limit(getattr(self, "user", None))
+                if not allowed:
+                    self.form_errors = [*self.form_errors, str(message)]
+                    self.email.errors = []
+                    self.password.errors = []
+                    return False
+            return is_valid
 
     return LoginForm
 
@@ -107,7 +121,28 @@ def send_confirmation_form_factory(Form, app):
                 self.user = current_datastore.get_user(self.data["email"])
             # Form is valid if user exists and they are not yet confirmed
             if self.user is not None and self.user.confirmed_at is None:
+                if app.config.get("ACCOUNTS_SEND_CONFIRMATION_RATELIMIT"):
+                    allowed, message = enforce_send_confirmation_limit(self.user)
+                    if not allowed:
+                        self.email.errors = [*self.email.errors, str(message)]
+                        return False
                 return True
             return False
 
     return SendConfirmationEmailView
+
+
+def forgot_password_form_factory(Form, app):
+    """Return forgot-password form with per-account rate limiting."""
+
+    class ForgotPasswordForm(Form):
+        def validate(self, extra_validators=None):
+            if not super().validate(extra_validators=extra_validators):
+                return False
+            allowed, message = enforce_forgot_password_limit(self.user)
+            if not allowed:
+                self.email.errors = [*self.email.errors, str(message)]
+                return False
+            return True
+
+    return ForgotPasswordForm

--- a/invenio_accounts/limiter.py
+++ b/invenio_accounts/limiter.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Forgot-password rate limit helpers."""
+
+from flask import current_app
+from limits import parse_many
+
+
+def _enforce_user_limit(user, limit_key, key_prefix_key, message_key):
+    limit_value = current_app.config.get(limit_key)
+    if not limit_value:
+        return True, None
+
+    limiter_ext = current_app.extensions["invenio-app"].limiter
+    key_prefix = current_app.config[key_prefix_key]
+
+    user_id = getattr(user, "id", None)
+    if user_id is None:
+        return True, None
+
+    key = str(user_id)
+
+    for item in parse_many(limit_value):
+        allowed = limiter_ext.limiter.hit(item, key_prefix, key)
+        if not allowed:
+            return False, current_app.config[message_key]
+    return True, None
+
+
+def enforce_forgot_password_limit(user):
+    """Return result for forgot-password per-account rate limit."""
+    return _enforce_user_limit(
+        user=user,
+        limit_key="ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT",
+        key_prefix_key="ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT_KEY_PREFIX",
+        message_key="ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT_MSG",
+    )
+
+
+def enforce_login_limit(user):
+    """Return result for login per-account rate limit."""
+    return _enforce_user_limit(
+        user=user,
+        limit_key="ACCOUNTS_LOGIN_RATELIMIT",
+        key_prefix_key="ACCOUNTS_LOGIN_RATELIMIT_KEY_PREFIX",
+        message_key="ACCOUNTS_LOGIN_RATELIMIT_MSG",
+    )
+
+
+def enforce_send_confirmation_limit(user):
+    """Return result for send-confirmation per-account rate limit."""
+    return _enforce_user_limit(
+        user=user,
+        limit_key="ACCOUNTS_SEND_CONFIRMATION_RATELIMIT",
+        key_prefix_key="ACCOUNTS_SEND_CONFIRMATION_RATELIMIT_KEY_PREFIX",
+        message_key="ACCOUNTS_SEND_CONFIRMATION_RATELIMIT_MSG",
+    )

--- a/invenio_accounts/templates/semantic-ui/invenio_accounts/login_user.html
+++ b/invenio_accounts/templates/semantic-ui/invenio_accounts/login_user.html
@@ -24,6 +24,7 @@
             <form action="{{ url_for_security('login') }}" method="POST"
                   name="login_user_form" class="ui big form">
               {{ form.hidden_tag() }}
+              {{ form_errors(form) }}
               {{ render_field(form.email, icon="user icon", autofocus=True, errormsg='email' in form.errors) }}
               {{ render_field(form.password, icon="lock icon", errormsg='password' in form.errors) }}
               <button type="submit" class="ui fluid large submit primary button">

--- a/invenio_accounts/views/rest.py
+++ b/invenio_accounts/views/rest.py
@@ -11,7 +11,7 @@
 
 from functools import wraps
 
-from flask import Blueprint, after_this_request, current_app, jsonify
+from flask import Blueprint, abort, after_this_request, current_app, jsonify
 from flask.views import MethodView
 from flask_login import login_required
 from flask_security import current_user
@@ -40,6 +40,7 @@ from webargs.flaskparser import FlaskParser as FlaskParserBase
 from invenio_accounts.models import SessionActivity
 from invenio_accounts.sessions import delete_session
 
+from ..limiter import enforce_login_limit, enforce_send_confirmation_limit
 from ..proxies import current_datastore, current_security
 from ..utils import (
     change_user_password,
@@ -274,6 +275,10 @@ class LoginView(MethodView, UserViewMixin):
             _abort(get_message("LOCAL_LOGIN_DISABLED")[0])
 
         user = self.get_user(**kwargs)
+        if current_app.config.get("ACCOUNTS_LOGIN_RATELIMIT"):
+            allowed, message = enforce_login_limit(user)
+            if not allowed:
+                abort(429, description=str(message))
         self.verify_login(user, **kwargs)
         self.login_user(user)
         return self.success_response(user)
@@ -530,6 +535,10 @@ class SendConfirmationEmailView(MethodView, UserViewMixin):
         """Send confirmation email."""
         user = self.get_user(**kwargs)
         self.verify(user)
+        if current_app.config.get("ACCOUNTS_SEND_CONFIRMATION_RATELIMIT"):
+            allowed, message = enforce_send_confirmation_limit(user)
+            if not allowed:
+                abort(429, description=str(message))
         self.send_confirmation_link(user)
         return self.success_response(user)
 

--- a/tests/test_auth_ratelimit.py
+++ b/tests/test_auth_ratelimit.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test per-account auth rate limits."""
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_app.ext import InvenioApp
+from invenio_db import db
+
+from invenio_accounts.forms import forgot_password_form_factory
+from invenio_accounts.testutils import create_test_user
+
+
+def _init_limiter(app, forgot_password_limit=None, **config):
+    app.config.update(
+        APP_ENABLE_SECURE_HEADERS=False,
+        RATELIMIT_STORAGE_URI="memory://",
+        **config,
+    )
+    if forgot_password_limit is not None:
+        app.config["ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT"] = forgot_password_limit
+        app.extensions["security"].forgot_password_form = forgot_password_form_factory(
+            app.extensions["security"].forgot_password_form,
+            app,
+        )
+    InvenioApp(app)
+
+    @app.errorhandler(429)
+    def _too_many_requests(error):
+        return str(error.description), 429
+
+
+def test_forgot_password_per_account_limit_blocks_second_request_same_email(app):
+    _init_limiter(app, forgot_password_limit="1 per minute")
+
+    with app.app_context():
+        create_test_user(email="normal@test.com")
+        with app.test_client() as client:
+            url = url_for_security("forgot_password")
+            first = client.post(
+                url,
+                data={"email": "NORMAL@TEST.COM"},
+            )
+            second = client.post(
+                url,
+                data={"email": "normal@test.com"},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code == 200
+            assert str(
+                app.config["ACCOUNTS_FORGOT_PASSWORD_EMAIL_RATELIMIT_MSG"]
+            ) in second.get_data(as_text=True)
+
+
+def test_forgot_password_per_account_limit_allows_different_emails(app):
+    _init_limiter(app, forgot_password_limit="1 per minute")
+
+    with app.app_context():
+        create_test_user(email="first@test.com")
+        create_test_user(email="second@test.com")
+        with app.test_client() as client:
+            url = url_for_security("forgot_password")
+            first = client.post(
+                url,
+                data={"email": "first@test.com"},
+            )
+            second = client.post(
+                url,
+                data={"email": "second@test.com"},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code != 429
+
+
+def test_forgot_password_per_account_limit_disabled_by_default(app):
+    _init_limiter(app)
+
+    with app.app_context():
+        create_test_user(email="normal@test.com")
+        with app.test_client() as client:
+            url = url_for_security("forgot_password")
+            first = client.post(
+                url,
+                data={"email": "normal@test.com"},
+            )
+            second = client.post(
+                url,
+                data={"email": "normal@test.com"},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code != 429
+
+
+def test_login_per_account_limit_blocks_second_attempt_ui(app):
+    _init_limiter(app, ACCOUNTS_LOGIN_RATELIMIT="1 per minute")
+
+    with app.app_context():
+        user = create_test_user(email="normal@test.com")
+        db.session.commit()
+        with app.test_client() as client:
+            url = url_for_security("login")
+            first = client.post(
+                url,
+                data={"email": user.email, "password": "wrong-password"},
+            )
+            second = client.post(
+                url,
+                data={"email": user.email, "password": "wrong-password"},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code == 200
+            assert str(app.config["ACCOUNTS_LOGIN_RATELIMIT_MSG"]) in second.get_data(
+                as_text=True
+            )
+            assert "invalid password" not in second.get_data(as_text=True).lower()
+
+
+def test_login_per_account_limit_blocks_second_attempt_rest(api):
+    _init_limiter(api, ACCOUNTS_LOGIN_RATELIMIT="1 per minute")
+
+    with api.app_context():
+        user = create_test_user(email="normal@test.com")
+        db.session.commit()
+        with api.test_client() as client:
+            url = url_for("invenio_accounts_rest_auth.login")
+            first = client.post(
+                url,
+                data={"email": user.email, "password": "wrong-password"},
+            )
+            second = client.post(
+                url,
+                data={"email": user.email, "password": "wrong-password"},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code == 429
+            assert second.get_data(as_text=True) == str(
+                api.config["ACCOUNTS_LOGIN_RATELIMIT_MSG"]
+            )
+
+
+def test_send_confirmation_per_account_limit_blocks_second_attempt_ui(app):
+    _init_limiter(app, ACCOUNTS_SEND_CONFIRMATION_RATELIMIT="1 per minute")
+
+    with app.app_context():
+        user = create_test_user(email="normal@test.com")
+        db.session.commit()
+        with app.test_client() as client:
+            url = url_for_security("send_confirmation")
+            first = client.post(
+                url,
+                data={"email": user.email},
+            )
+            second = client.post(
+                url,
+                data={"email": user.email},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code == 200
+            assert str(
+                app.config["ACCOUNTS_SEND_CONFIRMATION_RATELIMIT_MSG"]
+            ) in second.get_data(as_text=True)
+
+
+def test_send_confirmation_per_account_limit_blocks_second_attempt_rest(api):
+    _init_limiter(api, ACCOUNTS_SEND_CONFIRMATION_RATELIMIT="1 per minute")
+
+    with api.app_context():
+        user = create_test_user(email="normal@test.com")
+        db.session.commit()
+        with api.test_client() as client:
+            login_url = url_for("invenio_accounts_rest_auth.login")
+            login = client.post(
+                login_url,
+                data={"email": user.email, "password": "123456"},
+            )
+            assert login.status_code == 200
+
+            url = url_for("invenio_accounts_rest_auth.send_confirmation")
+            first = client.post(
+                url,
+                data={"email": user.email},
+            )
+            second = client.post(
+                url,
+                data={"email": user.email},
+            )
+
+            assert first.status_code != 429
+            assert second.status_code == 429
+            assert second.get_data(as_text=True) == str(
+                api.config["ACCOUNTS_SEND_CONFIRMATION_RATELIMIT_MSG"]
+            )


### PR DESCRIPTION
- Enforce per-account limits on forgot-password, login, and send-confirmation flows using user-id limiter keys.

- Add configurable rate-limit and key-prefix settings for each protected flow.
