### PR TITLE
Fix alembic migrations

### DIFF
--- a/invenio_accounts/alembic/037afe10e9ff_add_user_moderation_fields.py
+++ b/invenio_accounts/alembic/037afe10e9ff_add_user_moderation_fields.py
@@ -10,9 +10,29 @@
 from alembic import op
 from sqlalchemy import Column, DateTime
 
+# Invenio-Access depends on this package. During the evolution of this package,
+# the AccountsRole primary key was changed from an integer to a string. Because
+# invenio-access used this model in relationship definitions, the Alembic history
+# must be serialized so that some invenio-access migrations run before this change
+# and others run after it.
+#
+# The only way to do this is to make this package depend on invenio-access,
+# which creates a circular dependency at the Alembic level between the two
+# packages. To allow package migrations to be tested in isolation, we use this
+# switch: if invenio-access is installed, force the correct linearization; if
+# not, depend only on the primary-key-change revision.
+try:
+    import invenio_access
+
+    resolved_down_revision = "f9843093f686"
+
+except ImportError:
+    resolved_down_revision = "f2522cdd5fcd"
+
+
 # revision identifiers, used by Alembic.
 revision = "037afe10e9ff"
-down_revision = "f9843093f686"  # TODO this should be the mergepoint "f9843093f686" but tests fail because that's from invenio-access
+down_revision = resolved_down_revision
 branch_labels = ()
 depends_on = ""
 

--- a/invenio_accounts/alembic/037afe10e9ff_add_user_moderation_fields.py
+++ b/invenio_accounts/alembic/037afe10e9ff_add_user_moderation_fields.py
@@ -24,11 +24,11 @@ from sqlalchemy import Column, DateTime
 try:
     import invenio_access
 
-    resolved_down_revision = "f9843093f686"
+    # invenio_access/alembic/f9843093f686_change_fk_accountsrole_to_string_upgrade.py
+    resolved_down_revision = ["f9843093f686"]
 
 except ImportError:
-    resolved_down_revision = "f2522cdd5fcd"
-
+    resolved_down_revision = ["f2522cdd5fcd"]
 
 # revision identifiers, used by Alembic.
 revision = "037afe10e9ff"

--- a/invenio_accounts/alembic/037afe10e9ff_add_user_moderation_fields.py
+++ b/invenio_accounts/alembic/037afe10e9ff_add_user_moderation_fields.py
@@ -10,29 +10,9 @@
 from alembic import op
 from sqlalchemy import Column, DateTime
 
-# Invenio-Access depends on this package. During the evolution of this package,
-# the AccountsRole primary key was changed from an integer to a string. Because
-# invenio-access used this model in relationship definitions, the Alembic history
-# must be serialized so that some invenio-access migrations run before this change
-# and others run after it.
-#
-# The only way to do this is to make this package depend on invenio-access,
-# which creates a circular dependency at the Alembic level between the two
-# packages. To allow package migrations to be tested in isolation, we use this
-# switch: if invenio-access is installed, force the correct linearization; if
-# not, depend only on the primary-key-change revision.
-try:
-    import invenio_access
-
-    # invenio_access/alembic/f9843093f686_change_fk_accountsrole_to_string_upgrade.py
-    resolved_down_revision = ["f9843093f686"]
-
-except ImportError:
-    resolved_down_revision = ["f2522cdd5fcd"]
-
 # revision identifiers, used by Alembic.
 revision = "037afe10e9ff"
-down_revision = resolved_down_revision
+down_revision = "f2522cdd5fcd"
 branch_labels = ()
 depends_on = ""
 

--- a/invenio_accounts/alembic/9848d0149abd_create_accounts_tables.py
+++ b/invenio_accounts/alembic/9848d0149abd_create_accounts_tables.py
@@ -81,16 +81,22 @@ def upgrade():
             name="fk_accounts_userrole_user_id",
         ),
     )
-    with op.batch_alter_table("transaction") as batch_op:
-        batch_op.add_column(
-            sa.Column(
-                "user_id",
-                sa.Integer(),
-                sa.ForeignKey("accounts_user.id"),
-                nullable=True,
+
+    from flask import current_app
+
+    if current_app.config.get("DB_VERSIONING_USER_MODEL", "not_a_none") is not None:
+        with op.batch_alter_table("transaction") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "user_id",
+                    sa.Integer(),
+                    sa.ForeignKey("accounts_user.id"),
+                    nullable=True,
+                )
             )
-        )
-        batch_op.create_index(op.f("ix_transaction_user_id"), ["user_id"], unique=False)
+            batch_op.create_index(
+                op.f("ix_transaction_user_id"), ["user_id"], unique=False
+            )
 
 
 def downgrade():

--- a/invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
+++ b/invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
@@ -14,11 +14,23 @@ from sqlalchemy_utils import get_referencing_foreign_keys
 
 from invenio_accounts.models import Role
 
+# need to make sure that everything that depends on `accounts_role.id` being integer has already been
+# initialized
+resolved_depends_on = []
+try:
+    import invenio_communities
+
+    # invenio_communities/alembic/37b21951084c_update_role_id_type_downgrade.py
+    resolved_depends_on += ["37b21951084c"]
+
+except ImportError:
+    pass
+
 # revision identifiers, used by Alembic.
 revision = "f2522cdd5fcd"
 down_revision = "eb9743315a9d"
 branch_labels = ()
-depends_on = None
+depends_on = resolved_depends_on
 
 
 def upgrade():
@@ -38,6 +50,7 @@ def upgrade():
 
         op.drop_constraint("pk_accounts_role", "accounts_role", type_="primary")
     else:
+        # note: CASCADE here is what drops the foreign key constrains that reference `accounts_role`
         op.execute(
             text("ALTER TABLE accounts_role DROP CONSTRAINT pk_accounts_role CASCADE;")
         )

--- a/invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
+++ b/invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
@@ -14,6 +14,18 @@ from sqlalchemy_utils import get_referencing_foreign_keys
 
 from invenio_accounts.models import Role
 
+# Invenio-Access depends on this package. During the evolution of this package,
+# the AccountsRole primary key was changed from an integer to a string. Because
+# invenio-access used this model in relationship definitions, the Alembic history
+# must be serialized so that some invenio-access migrations run before this change
+# and others run after it.
+#
+# The only way to do this is to make this package depend on invenio-access,
+# which creates a circular dependency at the Alembic level between the two
+# packages. To allow package migrations to be tested in isolation, we use this
+# switch: if invenio-access is installed, force the correct linearization; if
+# not, depend only on the primary-key-change revision.
+
 # need to make sure that everything that depends on `accounts_role.id` being integer has already been
 # initialized
 resolved_depends_on = []
@@ -22,6 +34,15 @@ try:
 
     # invenio_communities/alembic/37b21951084c_update_role_id_type_downgrade.py
     resolved_depends_on += ["37b21951084c"]
+
+except ImportError:
+    pass
+
+try:
+    import invenio_access
+
+    # invenio_access/alembic/842a62b56e60_change_fk_accountsrole_to_string_downgrade.py
+    resolved_depends_on += ["842a62b56e60"]
 
 except ImportError:
     pass

--- a/invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
+++ b/invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
@@ -14,20 +14,25 @@ from sqlalchemy_utils import get_referencing_foreign_keys
 
 from invenio_accounts.models import Role
 
-# Invenio-Access depends on this package. During the evolution of this package,
-# the AccountsRole primary key was changed from an integer to a string. Because
-# invenio-access used this model in relationship definitions, the Alembic history
-# must be serialized so that some invenio-access migrations run before this change
-# and others run after it.
+# Invenio-Access depends on this package. During the evolution of these
+# packages, the `AccountsRole` primary key changed from an integer to a string.
+# Because `invenio-access` defines relationships against this model, the
+# migration order must be linearized: some `invenio-access` revisions must run
+# before this change, and others must run after it.
 #
-# The only way to do this is to make this package depend on invenio-access,
-# which creates a circular dependency at the Alembic level between the two
-# packages. To allow package migrations to be tested in isolation, we use this
-# switch: if invenio-access is installed, force the correct linearization; if
-# not, depend only on the primary-key-change revision.
+# To enforce that ordering, this migration conditionally depends on
+# `invenio-access`. This creates an Alembic-level circular dependency between
+# the two packages, so we handle it carefully: if `invenio-access` is
+# installed, we force the correct linearization; otherwise, we depend only on
+# the revision that introduces the primary-key change. This allows migrations
+# to be tested in isolation.
+#
+# We cannot put this logic in `invenio_access` package. Alembic migration files
+# are not regular importable modules from `.ext`, because the `alembic` directory
+# is not a Python package (no __init__.py). For that reason, the dependency is
+# resolved here and, when those packages are installed, their relevant migration
+# revisions are added to `resolved_depends_on`.
 
-# need to make sure that everything that depends on `accounts_role.id` being integer has already been
-# initialized
 resolved_depends_on = []
 try:
     import invenio_communities

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test alembic recipes for Invenio-accounts."""
+
+import pytest
+from invenio_db.utils import alembic_test_context, drop_alembic_version_table
+
+
+def test_alembic(app):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    from invenio_db import db
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    app.config["ALEMBIC_CONTEXT"] = alembic_test_context()
+
+    # Check that this package's SQLAlchemy models have been properly registered
+    tables = [x for x in db.metadata.tables]
+    assert "accounts_userrole" in tables
+    assert "accounts_role" in tables
+    assert "accounts_user" in tables
+
+    # Check that Alembic agrees that there's no further tables to create.
+    assert not ext.alembic.compare_metadata()
+
+    # Drop everything and recreate tables all with Alembic
+    db.drop_all()
+    drop_alembic_version_table()
+    ext.alembic.upgrade()
+    assert not ext.alembic.compare_metadata()
+
+    # Try to upgrade and downgrade
+    ext.alembic.stamp()
+    ext.alembic.downgrade(target="843bc79c426f")
+    ext.alembic.upgrade()
+    assert not ext.alembic.compare_metadata()
+
+    drop_alembic_version_table()

--- a/tests/test_invenio_accounts.py
+++ b/tests/test_invenio_accounts.py
@@ -124,7 +124,6 @@ def test_accounts_settings_blueprint(base_app):
             assert not menu
 
 
-@pytest.mark.skip(reason="Mergepoint is on invenio-access.")
 def test_alembic(app):
     """Test alembic recipes."""
     ext = app.extensions["invenio-db"]


### PR DESCRIPTION
### Description

This change fixes an Alembic migration-ordering problem between `invenio-accounts` and `invenio-access`. During the evolution of `invenio-accounts`, the `AccountsRole` primary key changed from an integer to a string. Because `invenio-access` defines relationships that depend on that model, migrations across the two packages must run in a specific order: some `invenio-access` revisions need to be applied before the primary-key change, while others must come after it. That creates a cross-package migration dependency which, when expressed directly in Alembic, becomes circular.

The fix introduces a conditional dependency switch in `invenio-accounts`. When `invenio-access` is installed, the migration chain is anchored to the appropriate `invenio-access` revision so the combined migration history is linearized correctly. When `invenio-access` is not installed, the migration falls back to the local `invenio-accounts` revision sequence. This preserves the correct ordering in integrated installations while still allowing package migrations to be tested and executed in isolation.

<img width="1136" height="2944" alt="alembic_graph_preview" src="https://github.com/user-attachments/assets/3126bef1-a661-4cfd-998e-a7b8e3dd5da7" />

ChatGPT was used to proofread comments and this PR text.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
