### PR TITLE
fix(tasks): reindex users after IP cleanup

### DIFF
--- a/invenio_accounts/config.py
+++ b/invenio_accounts/config.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2016-2026 CERN.
 # SPDX-FileCopyrightText: 2021 TU Wien.
-# SPDX-FileCopyrightText: 2022-2024 KTH Royal Institute of Technology
+# SPDX-FileCopyrightText: 2022-2026 KTH Royal Institute of Technology
 # SPDX-License-Identifier: MIT
 
 """Default configuration for ACCOUNTS."""
@@ -20,6 +20,10 @@ If False, you won't be able to login via the web UI.
 """
 
 ACCOUNTS_RETENTION_PERIOD = timedelta(days=30)
+"""Time after which login IP addresses are removed."""
+
+ACCOUNTS_IP_CLEANUP_BATCH_SIZE = 1000
+"""Maximum number of users processed per login IP cleanup batch."""
 
 ACCOUNTS_SESSION_STORE_FACTORY = (
     "invenio_accounts.sessions:default_session_store_factory"

--- a/invenio_accounts/tasks.py
+++ b/invenio_accounts/tasks.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2015-2025 CERN.
 # SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 
 """Background tasks for accounts."""
@@ -10,9 +11,10 @@ from celery import shared_task
 from flask import current_app
 from flask_mail import Message
 from invenio_db import db
-from sqlalchemy import func, or_
+from sqlalchemy import and_, func, or_
 
 from .models import Domain, LoginInformation, SessionActivity, User
+from .proxies import current_datastore, current_db_change_history
 from .sessions import delete_session
 
 
@@ -58,21 +60,66 @@ def clean_session_table():
 
 @shared_task
 def delete_ips():
-    """Automatically remove login_info.last_login_ip older than 30 days."""
-    expiration_date = (
-        datetime.now(timezone.utc) - current_app.config["ACCOUNTS_RETENTION_PERIOD"]
-    )
-
-    db.session.query(LoginInformation).filter(
+    """Remove expired login IPs and mark affected users for reindexing."""
+    now = datetime.now(timezone.utc)
+    expiration_date = now - current_app.config["ACCOUNTS_RETENTION_PERIOD"]
+    batch_size = current_app.config["ACCOUNTS_IP_CLEANUP_BATCH_SIZE"]
+    expired_last_login_ip = and_(
         LoginInformation.last_login_ip.isnot(None),
         LoginInformation.last_login_at < expiration_date,
-    ).update({LoginInformation.last_login_ip: None})
-
-    db.session.query(LoginInformation).filter(
+    )
+    expired_current_login_ip = and_(
         LoginInformation.current_login_ip.isnot(None),
         LoginInformation.current_login_at < expiration_date,
-    ).update({LoginInformation.current_login_ip: None})
-    db.session.commit()
+    )
+
+    while True:
+        affected_user_ids = [
+            row.user_id
+            for row in db.session.query(LoginInformation.user_id)
+            .filter(or_(expired_last_login_ip, expired_current_login_ip))
+            .order_by(LoginInformation.user_id)
+            .distinct()
+            .limit(batch_size)
+        ]
+        if not affected_user_ids:
+            return
+
+        try:
+            db.session.query(LoginInformation).filter(
+                LoginInformation.user_id.in_(affected_user_ids), expired_last_login_ip
+            ).update({LoginInformation.last_login_ip: None}, synchronize_session=False)
+
+            db.session.query(LoginInformation).filter(
+                LoginInformation.user_id.in_(affected_user_ids),
+                expired_current_login_ip,
+            ).update(
+                {LoginInformation.current_login_ip: None}, synchronize_session=False
+            )
+
+            db.session.query(User).filter(User.id.in_(affected_user_ids)).update(
+                {
+                    User.updated: db.func.now(),
+                    # User indexing uses version_id as the record revision, so
+                    # bulk changes must advance it to replace the search doc.
+                    User.version_id: User.version_id + 1,
+                },
+                synchronize_session=False,
+            )
+
+            # Bulk updates bypass ORM dirty tracking; mark IDs for post-commit reindex.
+            for user_id in affected_user_ids:
+                current_datastore.mark_changed(id(db.session), uid=user_id)
+
+            # Commit per batch to bound transactions and reindex task payloads.
+            current_datastore.commit()
+            current_app.logger.info(
+                "delete_ips task: cleared IPs for %d users", len(affected_user_ids)
+            )
+        except Exception:
+            db.session.rollback()
+            current_db_change_history.clear_dirty_sets(db.session)
+            raise
 
 
 @shared_task

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2015-2018 CERN.
 # SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 
 
@@ -7,7 +8,9 @@
 
 from datetime import datetime, timedelta, timezone
 from time import sleep
+from unittest import mock
 
+import pytest
 from flask import url_for
 from flask_login import login_required
 from flask_mail import Message
@@ -15,6 +18,7 @@ from flask_security import url_for_security
 from invenio_db import db
 
 from invenio_accounts.models import SessionActivity, User
+from invenio_accounts.proxies import current_datastore, current_db_change_history
 from invenio_accounts.tasks import clean_session_table, delete_ips, send_security_email
 from invenio_accounts.testutils import create_test_user
 
@@ -107,7 +111,7 @@ def test_clean_session_table(task_app):
             assert res.status_code == 302
 
 
-def test_delete_ips(task_app):
+def test_delete_ips(task_app, monkeypatch):
     """Test if ips are deleted after 30 days."""
     last_login_at1 = (
         datetime.now(timezone.utc)
@@ -117,6 +121,7 @@ def test_delete_ips(task_app):
     last_login_at2 = datetime.now(timezone.utc)
 
     with task_app.app_context():
+        task_app.config["ACCOUNTS_IP_CLEANUP_BATCH_SIZE"] = 1
         user1 = create_test_user(
             email="user1@invenio-software.org",
             last_login_ip="127.0.0.1",
@@ -140,17 +145,70 @@ def test_delete_ips(task_app):
             last_login_at=last_login_at1,
             current_login_at=last_login_at2,
         )
+        user_versions = {
+            user1.id: user1.version_id,
+            user2.id: user2.version_id,
+            user3.id: user3.version_id,
+        }
+
+        datastore = current_datastore._get_current_object()
+        marked_user_ids = []
+        original_mark_changed = datastore.mark_changed
+
+        def mark_changed(sid, uid=None, rid=None, model=None):
+            marked_user_ids.append(uid)
+            return original_mark_changed(sid, uid=uid, rid=rid, model=model)
+
+        monkeypatch.setattr(datastore, "mark_changed", mark_changed)
 
         delete_ips()
 
         user = db.session.query(User).filter(User.id == user1.id).one()
         assert user.last_login_ip is None
         assert user.current_login_ip is None
+        assert user.version_id == user_versions[user1.id] + 1
 
         user = db.session.query(User).filter(User.id == user2.id).one()
         assert user.last_login_ip is not None
         assert user.current_login_ip is not None
+        assert user.version_id == user_versions[user2.id]
 
         user = db.session.query(User).filter(User.id == user3.id).one()
         assert user.last_login_ip is None
         assert user.current_login_ip is not None
+        assert user.version_id == user_versions[user3.id] + 1
+
+        assert sorted(marked_user_ids) == sorted([user1.id, user3.id])
+
+
+def test_delete_ips_rolls_back_failed_batch(task_app):
+    """Test that IP cleanup rolls back when a batch fails before commit."""
+    last_login_at = (
+        datetime.now(timezone.utc)
+        - task_app.config["ACCOUNTS_RETENTION_PERIOD"]
+        - timedelta(days=1)
+    )
+
+    with task_app.app_context():
+        user = create_test_user(
+            email="rollback@invenio-software.org",
+            last_login_ip="127.0.0.1",
+            current_login_ip="127.0.0.1",
+            last_login_at=last_login_at,
+            current_login_at=last_login_at,
+        )
+        user_version = user.version_id
+        datastore = current_datastore._get_current_object()
+
+        with mock.patch.object(
+            datastore, "mark_changed", side_effect=RuntimeError("failed")
+        ):
+            with pytest.raises(RuntimeError):
+                delete_ips()
+
+        db.session.expire_all()
+        user = db.session.query(User).filter(User.id == user.id).one()
+        assert user.last_login_ip is not None
+        assert user.current_login_ip is not None
+        assert user.version_id == user_version
+        assert id(db.session) not in current_db_change_history.sessions


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

As requested:

* Update login IP cleanup to process expired records in batches and bump affected user versions.
* Mark changed users through the datastore so search indexes stay in sync after IP removal.
* Cover version updates and datastore change tracking in the IP cleanup task test.

For an easier review, here is how to test the changes:

1. Seed DB values: see [here](https://github.com/Samk13/invenio-dev-latest/blob/master/scripts/dev/user-check-tools/seed_users_login_info.py)
`uv run invenio shell scripts/dev/user-check-tools/seed_users_login_info.py`

2. Rebuild user index so DB and OpenSearch start aligned: see [here](https://github.com/Samk13/invenio-dev-latest/blob/master/scripts/indices-migration-v13-14/user-groups-indices-migration.py)
`uv run invenio shell scripts/indices-migration-v13-14/user-groups-indices-migration.py`

3. Check baseline: see [here](https://github.com/Samk13/invenio-dev-latest/blob/master/scripts/dev/user-check-tools/check_users_login_info_index.py)
`uv run invenio shell scripts/dev/user-check-tools/check_users_login_info_index.py`

Run the task with `invenio shell`
```py
from invenio_accounts.tasks import delete_ips
delete_ips()
```
run step 3 again and check the difference, or  check with curl:
```sh
curl --location --request GET 'http://localhost:9200/latest-build-users-user-v3.0.0-*/_search' \
--header 'Content-Type: application/json' \
--data '{
    "_source": ["_index", "_id", "email_hidden", "last_login_ip", "current_login_ip", "current_login_at","last_login_ip"]
}' | jq
```

Check the screenshot before and after running the script to see the number of users in db and indices should match.

## Before and after running the task:
<img width="905" height="684" alt="Screenshot 2026-06-11 at 14 36 14" src="https://github.com/user-attachments/assets/41fd971f-b584-46fd-a746-85953000c84a" />

## Before
<img width="849" height="832" alt="Screenshot 2026-06-11 at 14 34 29" src="https://github.com/user-attachments/assets/35f9e750-dbb6-47f3-944f-8dc205d5ab52" />

## After
<img width="861" height="832" alt="Screenshot 2026-06-11 at 14 36 40" src="https://github.com/user-attachments/assets/d1fa04a8-6fc7-4412-af6b-02431b1e0fd1" />

> Note: This PR includes AI-assisted contributions that have been reviewed, refined, and validated manually.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
