### PR TITLE
fix(session): only set session permanent if it wasn't permanent before

### DIFF
--- a/invenio_accounts/ext.py
+++ b/invenio_accounts/ext.py
@@ -338,7 +338,13 @@ class InvenioAccountsUI(InvenioAccounts):
 
         @app.before_request
         def make_session_permanent():
-            session.permanent = True
+            # `KVSession.modified` simply tracks if there were any write accesses
+            # to it, regardless of whether the value was actually changed or not.
+            # Since the `session.modified` marker is also used by Flask to determine
+            # if it should set a session cookie, and we don't want to have that
+            # set on every response, we avoid the write access here unless necessary.
+            if not session.permanent:
+                session.permanent = True
 
 
 def finalize_app(app):


### PR DESCRIPTION
Any write operation to the `KVSession` will mark it as modified.
Flask uses `session.modified` to check if it should add the session cookie to the response [1].
To avoid setting more session cookies on responses than necessary (e.g. because that's bad with HTTP caches), we avoid marking the session as modified unnecessarily here.

[1] https://github.com/pallets/flask/blob/3.1.3/src/flask/sessions.py#L245-L247